### PR TITLE
Use json-schema-merge-allof to merge allOf fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function serialize(object, contentType = 'yaml') {
  * @return {Promise<Object>} read and parsed object
  */
 async function readObject(file) {
-    return yaml.safeLoad(await fse.readFile(file, 'utf-8'), {filename: file});
+    return yaml.safeLoad(await fse.readFile(file, 'utf-8'), { filename: file });
 }
 
 /**
@@ -399,17 +399,19 @@ async function materializeModifiedSchemas(gitRoot = undefined, options = {}) {
             return p1.split('/').length - p2.split('/').length;
         });
 
-        const generatedFiles = _.flatten(await Promise.mapSeries(sortedSchemaPaths, (async (schemaPath) => {
-            const schemaFile = path.resolve(gitRoot, schemaPath);
-            const schemaDirectory = path.dirname(schemaFile);
-            options.log.info(`Materializing ${schemaFile}...`)
-            const schema = await readObject(schemaFile);
-            return materializeSchemaVersion(
-                schemaDirectory,
-                schema,
-                options
-            );
-        })));
+        const generatedFiles = _.flatten(
+            await Promise.mapSeries(sortedSchemaPaths, (async (schemaPath) => {
+                const schemaFile = path.resolve(gitRoot, schemaPath);
+                const schemaDirectory = path.dirname(schemaFile);
+                options.log.info(`Materializing ${schemaFile}...`);
+                const schema = await readObject(schemaFile);
+                return materializeSchemaVersion(
+                    schemaDirectory,
+                    schema,
+                    options
+                );
+            }))
+        );
 
         if (options.shouldGitAdd && !options.dryRun) {
             options.log.info(`New schema files have been generated. Adding them to git: ${generatedFiles}`);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const pino       = require('pino');
 const util       = require('util');
 const exec       = util.promisify(require('child_process').exec);
 const RefParser  = require('json-schema-ref-parser');
-const mergeAllof = require('json-schema-merge-allof');
+const mergeAllOf = require('json-schema-merge-allof');
 const Promise    = require('bluebird');
 
 /**
@@ -311,7 +311,7 @@ async function dereferenceSchema(schema, options = {}) {
             options.log.debug(
                 `Merging any allOf fields in schema with $id ${dereferencedSchema.$id}`
             );
-            return mergeAllof(dereferencedSchema, { ignoreAdditionalProperties: true });
+            return mergeAllOf(dereferencedSchema, { ignoreAdditionalProperties: true });
         })
         .catch((err) => {
             options.log.error(err, `Failed dereferencing schema with $id ${schema.$id}`, schema);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bluebird": "^3.5.5",
     "fs-extra": "^8.0.1",
     "js-yaml": "^3.13.1",
+    "json-schema-merge-allof": "^0.6.0",
     "json-schema-ref-parser": "^7.0.1",
     "lodash": "^4.17.11",
     "pino": "^5.12.6",

--- a/scripts/jsonschema-tools.js
+++ b/scripts/jsonschema-tools.js
@@ -238,6 +238,8 @@ const options = <%= JSON.stringify(options, null, 4) %>
 _.defaults(options, jsonschemaTools.defaultOptions);
 if (options.verbose) {
     options.log.level = 'debug';
+} else {
+    options.log.level = 'info';
 }
 
 jsonschemaTools.materializeModifiedSchemas(undefined, options).catch((err) => {

--- a/test/fixtures/schemas/basic/current.yaml
+++ b/test/fixtures/schemas/basic/current.yaml
@@ -3,25 +3,27 @@ description: Schema used for simple tests
 $id: /basic/1.2.0
 $schema: https://json-schema.org/draft-07/schema#
 type: object
-properties:
+additionalProperties: false
+allOf:
+  - $ref: /common/1.0.0
+  - properties:
 
-  # Include common properties we want in all schemas
-  $ref: /common/1.0.0#/properties
+      test:
+        type: string
+        default: default test
 
-  test:
-    type: string
-    default: default test
+      test_number:
+        type: number
 
-  test_number:
-    type: number
+      test_integer:
+        type: integer
 
-  test_integer:
-    type: integer
-
-  test_map:
-    description: >
-      We want to support 'map' types using additionalProperties to specify
-      the value types.  (Keys are always strings.)
-    type: object
-    additionalProperties:
-      type: string
+      test_map:
+        description: >
+          We want to support 'map' types using additionalProperties to specify
+          the value types.  (Keys are always strings.)
+        type: object
+        additionalProperties:
+          type: string
+    required:
+      - test

--- a/test/fixtures/schemas/common/1.0.0.yaml
+++ b/test/fixtures/schemas/common/1.0.0.yaml
@@ -14,3 +14,5 @@ properties:
   dt:
     type: string
     format: date-time
+required:
+  - $schema

--- a/test/fixtures/schemas/common/current.yaml
+++ b/test/fixtures/schemas/common/current.yaml
@@ -15,3 +15,5 @@ properties:
   dt:
     type: string
     format: date-time
+required:
+  - $schema

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const testFixture = require('test-fixture');
 const fse = require('fs-extra');
 const path = require('path');
@@ -11,6 +10,79 @@ const {
     materializeSchemaVersion,
 } = require('../index.js');
 
+
+/* eslint camelcase: 1 */
+const expectedBasicSchema = {
+    title: 'test/event',
+    description: 'Schema used for simple tests',
+    $id: '/basic/1.2.0',
+    $schema: 'https://json-schema.org/draft-07/schema#',
+    type: 'object',
+    additionalProperties: false,
+    allOf: [
+        { $ref: '/common/1.0.0' },
+        {
+            properties: {
+                test: {
+                    type: 'string',
+                    default: 'default test'
+                },
+                test_number: {
+                    type: 'number'
+                },
+                test_integer: {
+                    type: 'integer'
+                },
+                test_map: {
+                    description: 'We want to support \'map\' types using additionalProperties to specify the value types.  (Keys are always strings.)\n',
+                    type: 'object',
+                    additionalProperties: {
+                        type: 'string'
+                    }
+                }
+            },
+            required: ['test'],
+        }
+    ]
+};
+
+const expectedBasicDereferencedSchema = {
+    title: 'test/event',
+    description: 'Schema used for simple tests',
+    $id: '/basic/1.2.0',
+    $schema: 'https://json-schema.org/draft-07/schema#',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        $schema: {
+            type: 'string',
+            description: 'The URI identifying the jsonschema for this event. This may be just a short uri containing only the name and revision at the end of the URI path.  e.g. /schema_name/12345 is acceptable. This often will (and should) match the schema\'s $id field.\n',
+        },
+        dt: {
+            type: 'string',
+            format: 'date-time',
+        },
+        test: {
+            type: 'string',
+            default: 'default test'
+        },
+        test_number: {
+            type: 'number'
+        },
+        test_integer: {
+            type: 'integer'
+        },
+        test_map: {
+            description: 'We want to support \'map\' types using additionalProperties to specify the value types.  (Keys are always strings.)\n',
+            type: 'object',
+            additionalProperties: {
+                type: 'string'
+            }
+        }
+    },
+    required: ['$schema', 'test'],
+};
+/* eslint camelcase: 0 */
 
 describe('materializeSchemaVersion', async function() {
     let tests = [
@@ -26,6 +98,7 @@ describe('materializeSchemaVersion', async function() {
             expected: {
                 materializedPaths: ['schemas/basic/1.2.0.yaml', 'schemas/basic/1.2.0'],
                 symlinkPath: 'schemas/basic/1.2.0',
+                schema: expectedBasicSchema
             },
         },
         {
@@ -40,6 +113,7 @@ describe('materializeSchemaVersion', async function() {
             expected: {
                 materializedPaths: ['schemas/basic/1.2.0.yaml'],
                 symlinkPath: 'schemas/basic/1.2.0',
+                schema: expectedBasicSchema
             },
         },
         {
@@ -54,6 +128,7 @@ describe('materializeSchemaVersion', async function() {
             expected: {
                 materializedPaths: ['schemas/basic/1.2.0.json', 'schemas/basic/1.2.0'],
                 symlinkPath: 'schemas/basic/1.2.0',
+                schema: expectedBasicSchema
             },
         },
         {
@@ -68,6 +143,7 @@ describe('materializeSchemaVersion', async function() {
             expected: {
                 materializedPaths: ['schemas/basic/1.2.0.json'],
                 symlinkPath: 'schemas/basic/1.2.0',
+                schema: expectedBasicSchema
             },
         },
         {
@@ -82,6 +158,7 @@ describe('materializeSchemaVersion', async function() {
             expected: {
                 materializedPaths: ['schemas/basic/1.2.0.json', 'schemas/basic/1.2.0.yaml', 'schemas/basic/1.2.0'],
                 symlinkPath: 'schemas/basic/1.2.0',
+                schema: expectedBasicSchema
             },
         },
         {
@@ -96,46 +173,13 @@ describe('materializeSchemaVersion', async function() {
             expected: {
                 materializedPaths: ['schemas/basic/1.2.0.json', 'schemas/basic/1.2.0.yaml', 'schemas/basic/1.2.0'],
                 symlinkPath: 'schemas/basic/1.2.0',
+                schema: expectedBasicDereferencedSchema
             },
         },
     ];
 
 
     let fixture;
-
-    before('Loading expected schemas', async function() {
-        const fixturePath = 'test/fixtures';
-        // to avoid reading the same file over and over again, save read contents.
-        const schemas = {};
-
-        // These are referred to in basic/current.yaml as a $ref in the main properties.
-        // They will be added to expected dereferenced schemas.
-        const commonSchema = yaml.safeLoad(await fse.readFile(path.join(fixturePath, 'schemas', 'common', '1.0.0'), 'utf-8'));
-        const commonProperties = commonSchema.properties;
-
-        tests = await Promise.all(tests.map(async (test) => {
-            let expectedSchema = _.get(
-                schemas,
-                test.schemaPath,
-                yaml.safeLoad(await fse.readFile(path.join(fixturePath, test.schemaPath), 'utf-8'))
-            );
-            if (_.isUndefined(schemas[test.schemaPath])) {
-                schemas[test.schemaPath] = expectedSchema;
-            }
-
-            if (test.options.shouldDereference) {
-                // The only $ref in the expectedSchema is to /common/1.0.0#properties.
-                // Ensure those properties are in this version of the expected schema
-                // so we can compare it to a dereferenced one later.
-                expectedSchema = _.cloneDeep(expectedSchema);
-                _.merge(expectedSchema.properties, commonProperties);
-                delete expectedSchema.properties.$ref;
-            }
-
-            test.expected.schema = expectedSchema;
-            return test;
-        }));
-    });
 
     beforeEach('Copying fixtures to temp directory', async function() {
         // Copy the fixtures/ dir into a temp directory that is automatically
@@ -181,6 +225,7 @@ describe('materializeSchemaVersion', async function() {
             // Assert that all materialized files are what is expected.
             materializedFiles.forEach(async (materializedFile) => {
                 const materializedSchema = yaml.safeLoad(await fse.readFile(materializedFile, 'utf-8'));
+                // console.log(test.name, materializedSchema);
                 assert.deepStrictEqual(materializedSchema, test.expected.schema);
             });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -225,7 +225,6 @@ describe('materializeSchemaVersion', async function() {
             // Assert that all materialized files are what is expected.
             materializedFiles.forEach(async (materializedFile) => {
                 const materializedSchema = yaml.safeLoad(await fse.readFile(materializedFile, 'utf-8'));
-                // console.log(test.name, materializedSchema);
                 assert.deepStrictEqual(materializedSchema, test.expected.schema);
             });
         });


### PR DESCRIPTION
This allows for schemas to more easily include each other using
$ref and allOf.  E.g.

```yaml
allOf:
  - $ref: /path/to/common/schema/1.0.0
  - properties:
      myfieldA:
        type: string
    required:
      - myfieldA

```

Dereferencing this schema will now also merge everything from the common schema
with the properties for this schema, included any required properties.