### PR TITLE
Support loading options from config files; refactor git related commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "main": "index.js",


### PR DESCRIPTION
In order to ease use of jsonschema-tools as a library, this commit
adds support for reading in configs from config files, e.g.
.jsonschema-tools.yaml.  This yaml or json config file is an
object keyed by the same options described in the defaultOptions
documentation in index.js.

defaultOptions are always set, and then overridden by
provided config files, and then lastly by any CLI options
if running in CLI mode.  The config file will allow
easier configuration of schema repositories, without having
to manually provide CLI opts when running on the CLI (or
from the pre-commit hook), or when running as a JS library,
e.g. for tests.

Some CLI opts and function args have changed.

- git-root is no longer a CLI opt. When needed, git root
  will be discovered from the schema-base-path.

- The pre-commit hook installed by install-git-hook no longer
  renders custom options from the CLI as javascript.  If
  you need to customize the pre-commit hook, you should
  edit the .jsonschema-tools.yaml (or other) config file.

- materialize-modified will now by default look for unstaged
  schema files.  Staged ones likely only should be materialized
  during the pre-commit hook, so the pre-commit hook
  overrides this by passing --staged.

- materialize-modified takes an optional schema-base-path
  instead of the path to the git-root.

Note: the new readConfig function by default will only attempt
to read config files the first time it is called.  After that,
it expects that options has already been set by a previous
call to readConfig.  This allows to pass options around without
keeping global state by reading config the first time it is needed.
If you need to re-read config, just set the force arg to true.