### PR TITLE
Add ignoreSchemas option, use to ignore schemas with certain $id

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,11 @@ Options provided on the CLI will take precedence over those read from config.
      */
     shouldGitAdd: true,
     /**
+     * When finding schemas and info, if a schema's $id matches any regex here,
+     * it will not be included in results.
+     */
+    ignoreSchemas: [],
+    /**
      * special case option to ease setting log level to
      * debug from CLI (where pino is not easily configurable).
      * Pino's log.level will be set to this by the readConfig function.

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -68,6 +68,11 @@ const defaultOptions = {
      */
     shouldGitAdd: true,
     /**
+     * When finding schemas and info, if a schema's $id matches any regex here,
+     * it will not be included in results.
+     */
+    ignoreSchemas: [],
+    /**
      * Pino logger.
      */
     log: pino({ level: 'warn', prettyPrint: { translateTime: true, ignore: 'pid,hostname,level' }, }),
@@ -613,7 +618,8 @@ function schemaPathToInfo(schemaPath, options = {}) {
 /**
  * Looks in options.schemaBasePath for files that look like schema files.
  * These are either X.Y.Z.<contentType> files or currentName.<contentType>
- * files.
+ * files. Note: This function does not respect options.ignoreSchemas,
+ * since it does not read the discovered schema files.
  * @param {Object} options
  * @return {Array}
  */
@@ -663,6 +669,8 @@ function schemaInfoCompare(infoA, infoB) {
  * Looks in options.schemaBasePath for files that look like schema files and
  * then maps them using schemaPathToInfo, returning an object with
  * info and schema.
+ * If any schema $id matches a regex in options.ignoreSchemas, it will
+ * not be included in returned values.
  * @param {Object} options
  * @return {Object[]}
  */
@@ -671,7 +679,12 @@ function findAllSchemasInfo(options = {}) {
 
     const schemaPaths = findSchemaPaths(options);
     // Map each schema path to a schema info object, including the schema itself.
-    return schemaPaths.map(schemaPath => schemaPathToInfo(schemaPath, options))
+    return schemaPaths
+    .map(schemaPath => schemaPathToInfo(schemaPath, options))
+    .filter((schemaInfo) => {
+        const schemaId = _.get(schemaInfo.schema, '$id', '');
+        return !options.ignoreSchemas.find(pattern => schemaId.match(pattern));
+    })
     .sort(schemaInfoCompare);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "main": "index.js",

--- a/test/test.js
+++ b/test/test.js
@@ -265,6 +265,19 @@ describe('findSchemasByTitleAndMajor', function() {
         assert.strictEqual(latest.version, '1.2.0');
         assert.strictEqual(latest.current, true);
     });
+
+    it('should ignore schemas if they match ignoreSchemas config', function() {
+        const customOptions = {
+            schemaBasePath: fixture.resolve('schemas/'),
+            ignoreSchemas: [/\/basic\/1.1.0/],
+        };
+
+        const options = readConfig(customOptions, true);
+        const schemasByTitleAndMajor = findSchemasByTitleAndMajor(options);
+
+        const basicInfos = schemasByTitleAndMajor.basic['1'];
+        assert.deepStrictEqual(basicInfos.map(e => e.version), ['1.0.0', '1.2.0']);
+    });
 });
 
 


### PR DESCRIPTION
This will allow for manually configuring tests to skip
certain schema versions that do not conform to the
test requirements.