### PR TITLE
Create 'latest' symlink(s) when materializing schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Options provided on the CLI will take precedence over those read from config.
      */
     shouldSymlinkExtensionless: true,
     /**
-     * If true, materialize functions will symlink an 'latest' file
+     * If true, materialize functions will symlink a 'latest' file
      * to the latest version.contentTypes[0].
      */
     shouldSymlinkLatest: true,

--- a/README.md
+++ b/README.md
@@ -232,7 +232,12 @@ Options provided on the CLI will take precedence over those read from config.
      * to the version.contentTypes[0].  E.g. if contentTypes has 'yaml' as the first
      * entry, then 1.0.0 -> 1.0.0.yaml.
      */
-    shouldSymlink: true,
+    shouldSymlinkExtensionless: true,
+    /**
+     * If true, materialize functions will symlink an 'latest' file
+     * to the latest version.contentTypes[0].
+     */
+    shouldSymlinkLatest: true,
     /**
      * List of content types to output when materializing versioned schema files.
      */

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -23,7 +23,12 @@ const defaultOptions = {
      * to the version.contentTypes[0].  E.g. if contentTypes has 'yaml' as the first
      * entry, then 1.0.0 -> 1.0.0.yaml.
      */
-    shouldSymlink: true,
+    shouldSymlinkExtensionless: true,
+    /**
+     * If true, materialize functions will symlink an 'latest' file
+     * to the latest version.contentTypes[0].
+     */
+    shouldSymlinkLatest: true,
     /**
      * List of content types to output when materializing versioned schema files.
      */
@@ -435,6 +440,36 @@ async function gitModifiedSchemaPaths(options = {}) {
 }
 
 /**
+ * Given a path to a schema file, this returns an object describing the schema.
+ * If the schema at schemaPath does not have a title, assume it is invalid.
+ * A schema 'info' is an object like:
+ * {
+ *  title: 'schema/title',
+ *  path: '/path/to/schema/title/1.0.0.yaml',
+ *  version: '1.0.0',
+ *  current: true, // or false if this file is not the 'current' schema file.
+ *  contentType: 'yaml'
+ *  schema; {...}  // The schema (not dereferenced) schema object read from schemaPath.
+ * }
+ * @param {string} schemaPath path to schema file
+ * @param {Object} options
+ * @return {Object} {title, uri, version, current<boolean>, schema<Object>}
+ */
+function schemaPathToInfo(schemaPath, options = {}) {
+    options = readConfig(options);
+    const schema = readObjectSync(schemaPath);
+    const parsedPath = path.parse(schemaPath);
+    return {
+        title: _.get(schema, options.schemaTitleField, null),
+        path: schemaPath,
+        version: schemaVersion(schema, options.schemaVersionField),
+        current: parsedPath.base === options.currentName,
+        contentType: parsedPath.ext.slice(1),
+        schema,
+    };
+}
+
+/**
  * Uses the options.schemaBaseUris to create http and file schema resolvers
  * that prefix schema URIs in $refs with with the base URIs.  These
  * resolved URLs are then dereferenced in place.
@@ -488,6 +523,7 @@ async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
 
     return _.flatten(await Promise.all(options.contentTypes.map(async (contentType) => {
         let materializedFiles = [];
+
         const materializedSchemaPath = path.join(
             schemaDirectory, `${version}.${contentType}`
         );
@@ -500,21 +536,77 @@ async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
             log.info(`--dry-run: Would have materialized schema at ${materializedSchemaPath}.`);
         }
 
+
+        /**
+         * If configured to do so, and if the schema we are materializing
+         * has a semver later than whatever schema version latestSymlinkPath
+         * currently points to, then updates the latest symlink to point
+         * to this schema file we just materialized.
+         *
+         * This function will not take any action if !shouldSymlinkLatest
+         * or if dryRun.
+         *
+         * Any updated symlink path will be added to the materializedFiles list.
+         *
+         * This is DRYed out into a function so we can call it for this contentType
+         * as well as for an extensionless 'latest' below.
+         *
+         * NOTE: This does not extract the versions the path names, it uses the versions
+         *       from inside the schema itself.
+         *
+         * NOTE: This does not attempt to look for all schema versions.  This only
+         *       updates the latest symlink if THIS version is later than
+         *       whatever the latest symlink currently points to.  If
+         *       you do something silly like delete the latest symlink(s),
+         *       and then somehow materialize ONLY an OLD version of a schema,
+         *       This will set latest to that version. The version comparison
+         *       is only done if the latest symlink already exists.
+         * @param {string} latestSymlinkPath
+         */
+        async function updateLatestSymlink(latestSymlinkPath) {
+            // if latestSymlinkPath or the schema we just materialized has a later
+            // version than the one that latestSymlinkPath points to, then update
+            // latestSymlinkPath to point at this materializedSchemaPath.
+            if (options.shouldSymlinkLatest &&
+                (!fse.existsSync(latestSymlinkPath) ||
+                semver.compare(version, schemaPathToInfo(latestSymlinkPath, options).version) >= 0)
+            ) {
+                if (!options.dryRun) {
+                    await createSymlink(materializedSchemaPath, latestSymlinkPath);
+                    log.info(
+                        `Created latest symlink ${latestSymlinkPath} -> ${materializedSchemaPath}.`
+                    );
+                    materializedFiles.push(latestSymlinkPath);
+                } else {
+                    log.info(
+                        '--dry-run: Would have created latest symlink ' +
+                        `${latestSymlinkPath} to ${materializedSchemaPath}.`
+                    );
+                }
+            }
+        }
+
+        // Possibly update the latest symlink to point to this `version.contentType`.
+        await updateLatestSymlink(path.join(schemaDirectory, `latest.${contentType}`));
+
         // Only create the extensionless symlink to the first listed contentType.
-        if (options.shouldSymlink && contentType === options.contentTypes[0]) {
-            const symlinkPath = extensionlessPath(materializedSchemaPath);
+        if (options.shouldSymlinkExtensionless && contentType === options.contentTypes[0]) {
+            const extensionlessSymlinkPath = extensionlessPath(materializedSchemaPath);
             const target = path.basename(materializedSchemaPath);
             if (!options.dryRun) {
-                await createSymlink(target, symlinkPath);
+                await createSymlink(target, extensionlessSymlinkPath);
                 log.info(
-                    `Created extensionless symlink ${symlinkPath} -> ${target}.`
+                    `Created extensionless symlink ${extensionlessSymlinkPath} -> ${target}.`
                 );
-                materializedFiles.push(symlinkPath);
+                materializedFiles.push(extensionlessSymlinkPath);
             } else {
                 log.info(
-                    `--dry-run: Would have created extensionless symlink ${symlinkPath} to ${target}.`
+                    '--dry-run: Would have created extensionless symlink ' +
+                    `${extensionlessSymlinkPath} to ${target}.`
                 );
             }
+            // Also poossibly create an extensionless 'latest' symlink to this version.
+            await updateLatestSymlink(path.join(schemaDirectory, 'latest'));
         }
 
         return materializedFiles;
@@ -600,35 +692,6 @@ async function installGitHook(options) {
     }
 }
 
-/**
- * Given a path to a schema file, this returns an object describing the schema.
- * If the schema at schemaPath does not have a title, assume it is invalid.
- * A schema 'info' is an object like:
- * {
- *  title: 'schema/title',
- *  path: '/path/to/schema/title/1.0.0.yaml',
- *  version: '1.0.0',
- *  current: true, // or false if this file is not the 'current' schema file.
- *  contentType: 'yaml'
- *  schema; {...}  // The schema (not dereferenced) schema object read from schemaPath.
- * }
- * @param {string} schemaPath path to schema file
- * @param {Object} options
- * @return {Object} {title, uri, version, current<boolean>, schema<Object>}
- */
-function schemaPathToInfo(schemaPath, options = {}) {
-    options = readConfig(options);
-    const schema = readObjectSync(schemaPath);
-    const parsedPath = path.parse(schemaPath);
-    return {
-        title: _.get(schema, options.schemaTitleField, null),
-        path: schemaPath,
-        version: schemaVersion(schema, options.schemaVersionField),
-        current: parsedPath.base === options.currentName,
-        contentType: parsedPath.ext.slice(1),
-        schema,
-    };
-}
 
 /**
  * Looks in options.schemaBasePath for files that look like schema files.

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -25,7 +25,7 @@ const defaultOptions = {
      */
     shouldSymlinkExtensionless: true,
     /**
-     * If true, materialize functions will symlink an 'latest' file
+     * If true, materialize functions will symlink a 'latest' file
      * to the latest version.contentTypes[0].
      */
     shouldSymlinkLatest: true,
@@ -551,8 +551,8 @@ async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
          * This is DRYed out into a function so we can call it for this contentType
          * as well as for an extensionless 'latest' below.
          *
-         * NOTE: This does not extract the versions the path names, it uses the versions
-         *       from inside the schema itself.
+         * NOTE: This does not extract the versions from the path names, it uses the
+         *       versions from inside the schema itself.
          *
          * NOTE: This does not attempt to look for all schema versions.  This only
          *       updates the latest symlink if THIS version is later than

--- a/lib/tests/structure.js
+++ b/lib/tests/structure.js
@@ -67,6 +67,31 @@ function declareTests(options = { logLevel: 'warn' }) {
                     );
                 });
 
+
+                if (options.shouldSymlinkLatest) {
+                    it(`Should have latest.${latestSchemaInfo.contentType} symlink pointing to latest version file ${latestSchemaInfo.path}`, () => {
+                        const latestSymlinkPath = path.join(schemaDir, `latest.${latestSchemaInfo.contentType}`);
+                        assert.ok(fs.existsSync(latestSymlinkPath));
+                        assert.ok(fs.lstatSync(latestSymlinkPath).isSymbolicLink());
+                        assert.equal(
+                            fs.realpathSync(latestSymlinkPath),
+                            fs.realpathSync(path.join(schemaDir, `${latestSchemaInfo.version}.${options.contentTypes[0]}`))
+                        );
+                    });
+
+                    if (options.shouldSymlinkExtensionless) {
+                        it(`Should have extensionless latest symlink pointing to latest version file ${latestSchemaInfo.path}`, () => {
+                            const latestSymlinkPath = path.join(schemaDir, 'latest');
+                            assert.ok(fs.existsSync(latestSymlinkPath));
+                            assert.ok(fs.lstatSync(latestSymlinkPath).isSymbolicLink());
+                            assert.equal(
+                                fs.realpathSync(latestSymlinkPath),
+                                fs.realpathSync(path.join(schemaDir, `${latestSchemaInfo.version}.${options.contentTypes[0]}`)));
+                        });
+                    }
+                }
+
+
                 // Tests for each individual schema version, including current.
                 Object.keys(materializedSchemasInfosByVersion).forEach((version) => {
                     const schemaInfosForVersion = materializedSchemasInfosByVersion[version];
@@ -89,7 +114,7 @@ function declareTests(options = { logLevel: 'warn' }) {
                                 );
                             });
 
-                            if (options.shouldSymlink && contentType === options.contentTypes[0]) {
+                            if (options.shouldSymlinkExtensionless && contentType === options.contentTypes[0]) {
                                 it(`must have extensionless symlink version pointing to ${contentType}`, () => {
                                     const filePath = path.join(schemaDir, version);
                                     assert.ok(fs.existsSync(filePath));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "main": "index.js",

--- a/scripts/jsonschema-tools.js
+++ b/scripts/jsonschema-tools.js
@@ -134,8 +134,10 @@ const schemaBasePathArg = {
 function argsToOptions(args) {
     const options = {};
     _.keys(args).forEach((key) => {
-        if (key === 'noSymlink') {
-            options.shouldSymlink = !args[key];
+        if (key === 'noExtensionlessSymlink') {
+            options.shouldSymlinkExtensionless = !args[key];
+        } else if (key === 'noLatestSymlink') {
+            options.shouldSymlinkLatest = !args[key];
         } else if (key === 'noDereference') {
             options.shouldDereference = !args[key];
         } else if (key === 'noGitAdd') {

--- a/test/fixtures/jsonschema-tools.config1.yaml
+++ b/test/fixtures/jsonschema-tools.config1.yaml
@@ -1,3 +1,3 @@
-shouldSymlink: false
+shouldSymlinkExtensionless: false
 contentTypes: [json]
 shouldDereference: false

--- a/test/fixtures/jsonschema-tools.config2.yaml
+++ b/test/fixtures/jsonschema-tools.config2.yaml
@@ -1,2 +1,2 @@
-shouldSymlink: false
+shouldSymlinkExtensionless: false
 contentTypes: [yaml, json]


### PR DESCRIPTION
Add new shouldSymlinkExtensionless that if true, create's both latest.(json|yaml) as well as an
extensionless 'latest' symlink (if configured to do so) when materializing
schemas.  This symlinks will only ever be updated if jsonschema-tools
materializes a schema that has a greater version than the version
of the schema that the latest symlink currently points at.

Bug: [T245859](https://phabricator.wikimedia.org/T245859)