### PR TITLE
Validate examples against their schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,51 +236,52 @@ shouldSymlinkExtensionless: true
 shouldSymlinkLatest: true
 
 # List of content types to output when materializing versioned schema files.
-contentTypes: ['yaml', 'json'],
+contentTypes: ['yaml', 'json']
 
 # Name of 'current' schema file. Only these files will be considered
 # when materializing modified or 'all' schema files.
-currentName: 'current.yaml',
+currentName: current.yaml
 
 # Field in schema from which to extract the version using semver.coerce.
-schemaVersionField: '$id',
+schemaVersionField: '$id'
 
 # Field in schema from which to extract the schema title.
-schemaTitleField: 'title',
+schemaTitleField: title
 
 # If true, materialize functions will first dereference schemas before outputting them.
-shouldDereference: true,
+shouldDereference: true
 
 # Path in which (current) schemas will be looked for.
-schemaBasePath: process.cwd(),
+# Default process.cwd()
+schemaBasePath: ./
 
 # These are the URIs that will be used when resolving schemas.
 # If not set, the readConfig function will set this to [schemaBasePath]
-schemaBaseUris: undefined,
+schemaBaseUris: null
 
 # If true, don't actually modify anything, just log what would have been done.
-dryRun: false,
+dryRun: false
 
 # If true, only git staged current schema files will be considered by materializeModified.
 # If false, only unstaged current schema files will be considerd by materializeModified.
-gitStaged: false,
+gitStaged: false
 
 # If true, materializeModified will `git add` any versioned schema files it materializes.
-shouldGitAdd: true,
+shouldGitAdd: true
 
 # When finding schemas and info, if a schema's $id matches any regex here,
 # it will not be included in results.
-ignoreSchemas: [],
+ignoreSchemas: []
 
 # special case option to ease setting log level to
 # debug from CLI (where pino is not easily configurable).
 # Pino's log.level will be set to this by the readConfig function.
-logLevel: 'warn',
+logLevel: warn
 
 # Array of default config files from which custom
 # options will be read by readConfig.
 # The keys in these config files are the same as these defaultOptions keys.
-configPaths: ['./.jsonschema-tools.yaml'],
+configPaths: ['./.jsonschema-tools.yaml']
 ```
 
 # Schema Repository Tests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In a event stream based architecture, schemas define a contract between
 disparate producers and consumers of data.  Thrift, Protocol Buffers, and Avro
 are all schema based data formats, but can be difficult to use in different
 settings.  These are binary formats, and as such the having schema is requried to
-read data.  Distributing up to data schemas to all users of the data can be difficult,
+read data.  Distributing up to date schemas to all users of the data can be difficult,
 especially when those users are in different organizations.
 
 JSON is a ubiquitous data format, but it can be difficult to work with in strongly
@@ -24,7 +24,7 @@ However, unlike Avro, there is no built in support for evolving JSONSchemas over
 This library helps with managing a repository of evolving JSONSchemas.  It is intended
 to be used in a git repository to materialize staticly versioned schema files as
 your schema evolves.  By having all schema versions materialized as static files,
-a schema repository could be shared to clients either via git, or via a static
+a schema repository could be shared to clients either via git or a static
 http fileserver. An http fileserver on top of a git repository that contains
 predictable schema URLs can act much like Confluent's Avro schema registry,
 but with the benifits of decentralization provided by git.
@@ -198,12 +198,12 @@ materialize modified current files found during a git commit.
 Install jsonschema-tools as a depenendency in your schema repository (or
 globally somewhere), then run `jsonschema-tools install-git-hook` from
 your git working copy checkout.  This will install .git/hooks/pre-commit.
-pre-commit is a NodeJS script, so `require('jsonschema-tools')` must work
+pre-commit is a NodeJS script, so `require('@wikimedia/jsonschema-tools')` must work
 from within your git checkout.
 
 ## As an NPM dependency
 Alternatively, you can make jsonschema-tools an npm dependency in your
-schema git repository, and at an npm `postinstall` script to automatically
+schema git repository, and add an npm `postinstall` script to automatically
 install the jsonschema-tools pre-commit hook for any user of the repository.
 Add the following to your package.json:
 
@@ -214,7 +214,7 @@ Add the following to your package.json:
   },
   "devDependencies": {
     ...,
-    "@wikimedia/jsonschema-tools": "^0.3.0"
+    "@wikimedia/jsonschema-tools": "latest"
   }
 ```
 
@@ -225,80 +225,62 @@ available config option overrides are documented below.
 
 Options provided on the CLI will take precedence over those read from config.
 
-```javascript
-{
-   /**
-     * If true, materialize functions will symlink an extensionless versioned file
-     * to the version.contentTypes[0].  E.g. if contentTypes has 'yaml' as the first
-     * entry, then 1.0.0 -> 1.0.0.yaml.
-     */
-    shouldSymlinkExtensionless: true,
-    /**
-     * If true, materialize functions will symlink a 'latest' file
-     * to the latest version.contentTypes[0].
-     */
-    shouldSymlinkLatest: true,
-    /**
-     * List of content types to output when materializing versioned schema files.
-     */
-    contentTypes: ['yaml', 'json'],
-    /**
-     * Name of 'current' schema file. Only these files will be considered
-     * when materializing modified or 'all' schema files.
-     */
-    currentName: 'current.yaml',
-    /**
-     * Field in schema from which to extract the version using semver.coerce.
-     */
-    schemaVersionField: '$id',
-    /**
-     * Field in schema from which to extract the schema title.
-     */
-    schemaTitleField: 'title',
-    /**
-     * If true, materialize functions will first dereference schemas before outputting them.
-     */
-    shouldDereference: true,
-    /**
-     * Path in which (current) schemas will be looked for.
-     */
-    schemaBasePath: process.cwd(),
-    /**
-     * These are the URIs that will be used when resolving schemas.
-     * If not set, the readConfig function will set this to [schemaBasePath]
-     */
-    schemaBaseUris: undefined,
-    /**
-     * If true, don't actually modify anything, just log what would have been done.
-     */
-    dryRun: false,
-    /**
-     * If true, only git staged current schema files will be considered by materializeModified.
-     * If false, only unstaged current schema files will be considerd by materializeModified.
-     */
-    gitStaged: false,
-    /**
-     * If true, materializeModified will `git add` any versioned schema files it materializes.
-     */
-    shouldGitAdd: true,
-    /**
-     * When finding schemas and info, if a schema's $id matches any regex here,
-     * it will not be included in results.
-     */
-    ignoreSchemas: [],
-    /**
-     * special case option to ease setting log level to
-     * debug from CLI (where pino is not easily configurable).
-     * Pino's log.level will be set to this by the readConfig function.
-     */
-    logLevel: 'warn',
-    /**
-     * Array of default config files from which custom
-     * options will be read by readConfig.
-     * The keys in these config files are the same as these defaultOtions keys.
-     */
-    configPaths: ['./.jsonschema-tools.yaml'],
-}
+```yaml
+# If true, materialize functions will symlink an extensionless versioned file
+# to the version.contentTypes[0].  E.g. if contentTypes has 'yaml' as the first
+# entry, then 1.0.0 -> 1.0.0.yaml.
+shouldSymlinkExtensionless: true
+
+# If true, materialize functions will symlink a 'latest' file
+# to the latest version.contentTypes[0].
+shouldSymlinkLatest: true
+
+# List of content types to output when materializing versioned schema files.
+contentTypes: ['yaml', 'json'],
+
+# Name of 'current' schema file. Only these files will be considered
+# when materializing modified or 'all' schema files.
+currentName: 'current.yaml',
+
+# Field in schema from which to extract the version using semver.coerce.
+schemaVersionField: '$id',
+
+# Field in schema from which to extract the schema title.
+schemaTitleField: 'title',
+
+# If true, materialize functions will first dereference schemas before outputting them.
+shouldDereference: true,
+
+# Path in which (current) schemas will be looked for.
+schemaBasePath: process.cwd(),
+
+# These are the URIs that will be used when resolving schemas.
+# If not set, the readConfig function will set this to [schemaBasePath]
+schemaBaseUris: undefined,
+
+# If true, don't actually modify anything, just log what would have been done.
+dryRun: false,
+
+# If true, only git staged current schema files will be considered by materializeModified.
+# If false, only unstaged current schema files will be considerd by materializeModified.
+gitStaged: false,
+
+# If true, materializeModified will `git add` any versioned schema files it materializes.
+shouldGitAdd: true,
+
+# When finding schemas and info, if a schema's $id matches any regex here,
+# it will not be included in results.
+ignoreSchemas: [],
+
+# special case option to ease setting log level to
+# debug from CLI (where pino is not easily configurable).
+# Pino's log.level will be set to this by the readConfig function.
+logLevel: 'warn',
+
+# Array of default config files from which custom
+# options will be read by readConfig.
+# The keys in these config files are the same as these defaultOptions keys.
+configPaths: ['./.jsonschema-tools.yaml'],
 ```
 
 # Schema Repository Tests

--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ SQL based systems.
 - All fields are in snake_case format
 - All fields have monomorphic types
 - All required properties are defined
+- JSONSchema examples validate against their schema
+- JSONSchema examples $schema field matches their schema $id
 
 ## compatibility
 - All materialized schemas with the same major version must be backwards compatible

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -90,7 +90,7 @@ const defaultOptions = {
     /**
      * Array of default config files from which custom
      * options will be read by readConfig.
-     * The keys in these config files are the same as these defaultOtions keys.
+     * The keys in these config files are the same as these defaultOptions keys.
      */
     configPaths: ['./.jsonschema-tools.yaml'],
 };

--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -108,7 +108,7 @@ function declareTests(options = {}) {
                             });
 
                         if (schemaInfo.schema.examples) {
-                            it('examples must validate against schema', () => {
+                            it('examples must validate against schema and have $schema == $id', () => {
                                 const examples = schemaInfo.schema.examples;
 
                                 // We need a new Ajv each time so we don't
@@ -130,6 +130,11 @@ function declareTests(options = {}) {
                                 examples.forEach((example) => {
                                     const result = ajvForTest.validate(schemaInfo.schema, example);
                                     assert.ok(result, ajvForTest.errorsText());
+
+                                    assert.strictEqual(
+                                        example.$schema, schemaInfo.schema.$id,
+                                        'examples $schema value must match schema\'s $id value'
+                                    );
                                 });
                             });
                         }

--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -9,6 +9,16 @@ const ajv = new Ajv({
 });
 const isSchemaValid = ajv.compile(require('ajv/lib/refs/json-schema-draft-07.json'));
 const isSchemaSecure = ajv.compile(require('ajv/lib/refs/json-schema-secure.json'));
+// Both http and https can be used as the draft-07 $schema URL.
+// However, the draft-07 metaschema uses an http URL as its
+// $id field.  AJV caches schemas by their $id.  In order
+// to avoid a remote lookup of this metaschema if a
+// schema sets $schema to https, we manually cache the
+// local copy of draft-07 metaschema with the https URL.
+ajv.addSchema(
+    require('ajv/lib/refs/json-schema-draft-07.json'),
+    'https://json-schema.org/draft-07/schema'
+);
 
 const assertMonomorphTypes = (node, path = '') => {
     if (Array.isArray(node.type)) {
@@ -111,30 +121,22 @@ function declareTests(options = {}) {
                             it('examples must validate against schema and have $schema == $id', () => {
                                 const examples = schemaInfo.schema.examples;
 
-                                // We need a new Ajv each time so we don't
-                                // use schema cached by $id which is the same
-                                // for each content type.
-                                const ajvForTest = new Ajv();
-
-                                // Both http and https can be used as the draft-07 $schema URL.
-                                // However, the draft-07 metaschema uses an http URL as its
-                                // $id field.  AJV caches schemas by their $id.  In order
-                                // to avoid a remote lookup of this metaschema if a
-                                // schema sets $schema to https, we manually cache the
-                                // local copy of draft-07 metaschema with the https URL.
-                                ajvForTest.addSchema(
-                                    require('ajv/lib/refs/json-schema-draft-07.json'),
-                                    'https://json-schema.org/draft-07/schema'
-                                );
-
                                 examples.forEach((example) => {
-                                    const result = ajvForTest.validate(schemaInfo.schema, example);
-                                    assert.ok(result, ajvForTest.errorsText());
+                                    const result = ajv.validate(schemaInfo.schema, example);
+                                    assert.ok(result, ajv.errorsText());
 
                                     assert.strictEqual(
                                         example.$schema, schemaInfo.schema.$id,
                                         'examples $schema value must match schema\'s $id value'
                                     );
+
+                                    // Remove the schema we added from ajv's schema cache.
+                                    // We need to re-add this schema for every materialized
+                                    // file type that exists to make sure they all work
+                                    // as they should.  If we don't remove, ajv will
+                                    // see that the schema has already been added by
+                                    // its $id and fail with an error.
+                                    ajv.removeSchema(schemaInfo.schema.$id);
                                 });
                             });
                         }

--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -69,7 +69,10 @@ function declareTests(options = {}) {
         for (const title of Object.keys(allSchemas)) {
             describe(title, () => {
                 allSchemas[title].forEach((schemaInfo) => {
-                    describe(schemaInfo.current ? 'current' : schemaInfo.version, () => {
+                    const testName = (schemaInfo.current ? 'current' : schemaInfo.version) +
+                        (schemaInfo.contentType ? `.${schemaInfo.contentType}` : '');
+
+                    describe(testName, () => {
                         const schema = schemaInfo.schema;
                         it('must be valid JSON-Schema', () => {
                             if (!isSchemaValid(schema)) {
@@ -103,6 +106,33 @@ function declareTests(options = {}) {
                             it('all required properties must exist', () => {
                                 assertRequired(schema);
                             });
+
+                        if (schemaInfo.schema.examples) {
+                            it('examples must validate against schema', () => {
+                                const examples = schemaInfo.schema.examples;
+
+                                // We need a new Ajv each time so we don't
+                                // use schema cached by $id which is the same
+                                // for each content type.
+                                const ajvForTest = new Ajv();
+
+                                // Both http and https can be used as the draft-07 $schema URL.
+                                // However, the draft-07 metaschema uses an http URL as its
+                                // $id field.  AJV caches schemas by their $id.  In order
+                                // to avoid a remote lookup of this metaschema if a
+                                // schema sets $schema to https, we manually cache the
+                                // local copy of draft-07 metaschema with the https URL.
+                                ajvForTest.addSchema(
+                                    require('ajv/lib/refs/json-schema-draft-07.json'),
+                                    'https://json-schema.org/draft-07/schema'
+                                );
+
+                                examples.forEach((example) => {
+                                    const result = ajvForTest.validate(schemaInfo.schema, example);
+                                    assert.ok(result, ajvForTest.errorsText());
+                                });
+                            });
+                        }
                         }
                     });
                 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "main": "index.js",


### PR DESCRIPTION
it is nice if schema authors add [examples](https://json-schema.org/understanding-json-schema/reference/generic.html) to their schemas.  Add a test to ensure that provided examples validate against their schema and that the example $schema value matches the $id of the schema.
