### PR TITLE
Add option to enforce bounds for number fields

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -1,17 +1,18 @@
 'use strict';
 
-const _           = require('lodash');
-const yaml        = require('js-yaml');
-const path        = require('path');
-const semver      = require('semver');
-const readdirSync = require('recursive-readdir-sync');
-const fse         = require('fs-extra');
-const pino        = require('pino');
-const util        = require('util');
-const exec        = util.promisify(require('child_process').exec);
-const RefParser   = require('json-schema-ref-parser');
-const mergeAllOf  = require('json-schema-merge-allof');
-const Promise     = require('bluebird');
+const _              = require('lodash');
+const yaml           = require('js-yaml');
+const path           = require('path');
+const semver         = require('semver');
+const readdirSync    = require('recursive-readdir-sync');
+const fse            = require('fs-extra');
+const pino           = require('pino');
+const util           = require('util');
+const exec           = util.promisify(require('child_process').exec);
+const RefParser      = require('json-schema-ref-parser');
+const mergeAllOf     = require('json-schema-merge-allof');
+const traverseSchema = require('json-schema-traverse');
+const Promise        = require('bluebird');
 
 /**
  * Default options for various functions in this library.
@@ -93,6 +94,14 @@ const defaultOptions = {
      * The keys in these config files are the same as these defaultOptions keys.
      */
     configPaths: ['./.jsonschema-tools.yaml'],
+    /**
+     * Check the existing numeric bounds for a number field, and enforce a number type.
+     * For more flexibility and clarity, number types are expressed here as an array of
+     * the minimum and maximum numbers allowed.
+     * The tool will add `minimum` and `maximum` properties if they aren't present, and
+     * will modify their value if they outside the configured bounds.
+     */
+    enforcedNumericBounds: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
 };
 
 
@@ -534,6 +543,23 @@ async function dereferenceSchema(schema, options = {}) {
 }
 
 /**
+ * Outputs a given schema with any modifications specified in the options,
+ * including but not limited to dereferencing and enforcing numeric bounds.
+ *
+ * @param {Object} schema Schema to materialize
+ * @param {Object} options
+ */
+async function materializeSchema (schema, options) {
+    if (options.shouldDereference) {
+        schema = await dereferenceSchema(schema, options);
+    }
+    if (options.enforcedNumericBounds) {
+        schema = enforceNumericBounds(schema, options.enforcedNumericBounds);
+    }
+    return schema;
+}
+
+/**
  * Materializes a versioned schema file in the directory.
  *
  * @param {string} schemaDirectory directory in which to materialize schema
@@ -541,15 +567,13 @@ async function dereferenceSchema(schema, options = {}) {
  * @param {Object} options
  * @return {Promise<string>} path of newly materialized files
  */
-async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
+async function materializeSchemaToPath(schemaDirectory, schema, options = {}) {
     options = readConfig(options);
     const log = options.log;
 
     const version = schemaVersion(schema, options.schemaVersionField);
 
-    if (options.shouldDereference) {
-        schema = await dereferenceSchema(schema, options);
-    }
+    schema = await materializeSchema(schema, options);
 
     return _.flatten(await Promise.all(options.contentTypes.map(async (contentType) => {
         let materializedFiles = [];
@@ -641,7 +665,19 @@ async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
 
         return materializedFiles;
     })));
+}
 
+/**
+ * @deprecated
+ * Materializes a versioned schema file in the directory.
+ *
+ * @param {string} schemaDirectory directory in which to materialize schema
+ * @param {Object} schema Schema to materialize
+ * @param {Object} options
+ * @return {Promise<string>} path of newly materialized files
+ */
+async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
+    return materializeSchemaToPath(schemaDirectory, schema, options)
 }
 
 /**
@@ -676,7 +712,7 @@ async function materializeModifiedSchemas(options = {}) {
                 const schemaDirectory = path.dirname(schemaPath);
                 options.log.info(`Materializing ${schemaPath}...`);
                 const schema = await readObject(schemaPath);
-                return materializeSchemaVersion(
+                return materializeSchemaToPath(
                     schemaDirectory,
                     schema,
                     options
@@ -859,8 +895,28 @@ async function materializeAllSchemas(options = {}) {
 
     return _.flatten(await Promise.all(_.map(
         currentSchemasInfo,
-        info => materializeSchemaVersion(path.dirname(info.path), info.schema, options)
+        info => materializeSchemaToPath(path.dirname(info.path), info.schema, options)
     )));
+}
+
+/**
+ * Traverses through all the fields in the schema, including nested properties, and
+ * sets the numeric bounds specified in options when the object type is number.
+ * @param {Object} schema
+ * @param {Array} bounds as specified in options
+ * @return {Object} schema with bounded numeric fields
+ */
+function enforceNumericBounds(schema, bounds) {
+    const schemaCopy = _.cloneDeep(schema);
+    const enforcedMin = bounds[0];
+    const enforcedMax = bounds[1];
+    traverseSchema(schemaCopy, (obj) => {
+        if (['number', 'integer', 'float'].includes(obj.type)) {
+            obj.minimum = Math.max(enforcedMin, obj.minimum || -Infinity);
+            obj.maximum = Math.min(enforcedMax, obj.maximum || Infinity);
+        }
+    })
+    return schemaCopy;
 }
 
 
@@ -872,7 +928,8 @@ module.exports = {
     gitAdd,
     installGitHook,
     getSchemaById,
-    dereferenceSchema,
+    materializeSchema,
+    materializeSchemaToPath,
     materializeSchemaVersion,
     materializeModifiedSchemas,
     materializeAllSchemas,

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -98,8 +98,8 @@ const defaultOptions = {
      * Check the existing numeric bounds for a number field, and enforce a number type.
      * For more flexibility and clarity, number types are expressed here as an array of
      * the minimum and maximum numbers allowed.
-     * The tool will add `minimum` and `maximum` properties if they aren't present, and
-     * will modify their value if they outside the configured bounds.
+     * The tool will add inclusive `minimum` and `maximum` properties if they aren't
+     * present, and will modify their value if they outside the configured bounds.
      */
     enforcedNumericBounds: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
 };
@@ -548,6 +548,7 @@ async function dereferenceSchema(schema, options = {}) {
  *
  * @param {Object} schema Schema to materialize
  * @param {Object} options
+ * @return {Object} modified schema
  */
 async function materializeSchema (schema, options) {
     if (options.shouldDereference) {
@@ -911,7 +912,7 @@ function enforceNumericBounds(schema, bounds) {
     const enforcedMin = bounds[0];
     const enforcedMax = bounds[1];
     traverseSchema(schemaCopy, (obj) => {
-        if (['number', 'integer', 'float'].includes(obj.type)) {
+        if (['number', 'integer'].includes(obj.type)) {
             obj.minimum = Math.max(enforcedMin, obj.minimum || -Infinity);
             obj.maximum = Math.min(enforcedMax, obj.maximum || Infinity);
         }

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -913,8 +913,8 @@ function enforceNumericBounds(schema, bounds) {
     const enforcedMax = bounds[1];
     traverseSchema(schemaCopy, (obj) => {
         if (['number', 'integer'].includes(obj.type)) {
-            obj.minimum = Math.max(enforcedMin, obj.minimum || -Infinity);
-            obj.maximum = Math.min(enforcedMax, obj.maximum || Infinity);
+            obj.minimum = obj.minimum || enforcedMin;
+            obj.maximum = obj.maximum || enforcedMax;
         }
     })
     return schemaCopy;

--- a/lib/tests/structure.js
+++ b/lib/tests/structure.js
@@ -105,8 +105,7 @@ function declareTests(options = { logLevel: 'warn' }) {
                         currentSchemaInfo.version,
                         `Current and latest schema versions read from ${options.schemaVersionField} do not match`
                     );
-
-                    const dereferencedCurrentSchema = await jsonschemaTools.dereferenceSchema(
+                    const dereferencedCurrentSchema = await jsonschemaTools.materializeSchema(
                         currentSchemaInfo.schema,
                         options,
                     );

--- a/lib/tests/structure.js
+++ b/lib/tests/structure.js
@@ -6,6 +6,7 @@ const assert = require('assert').strict;
 const fs = require('fs');
 const semver = require('semver');
 const jsonschemaTools = require('../jsonschema-tools.js');
+const traverseSchema = require('json-schema-traverse');
 
 function declareTests(options = { logLevel: 'warn' }) {
 
@@ -136,6 +137,19 @@ function declareTests(options = { logLevel: 'warn' }) {
                             assert.equal(
                                 fs.realpathSync(latestSymlinkPath),
                                 fs.realpathSync(path.join(schemaDir, `${latestSchemaInfo.version}.${options.contentTypes[0]}`)));
+                        });
+                    }
+
+                    if (options.enforcedNumericBounds) {
+                        it(`Should not have minimum or maximum values outside the bounds specified in options ${latestSchemaInfo.path}`, () => {
+                            const enforcedMin = options.enforcedNumericBounds[0];
+                            const enforcedMax = options.enforcedNumericBounds[1];
+                            traverseSchema(latestSchemaInfo.schema, (obj) => {
+                                if (['number', 'integer'].includes(obj.type)) {
+                                    assert.ok(obj.minimum >= enforcedMin, 'has a minimum value lower than allowed by the config');
+                                    assert.ok(obj.maximum <= enforcedMax, 'has a maximum value higher than allowed by the config');
+                                }
+                            })
                         });
                     }
                 }

--- a/lib/tests/structure.js
+++ b/lib/tests/structure.js
@@ -141,6 +141,16 @@ function declareTests(options = { logLevel: 'warn' }) {
                     }
 
                     if (options.enforcedNumericBounds) {
+                        it(`Should have minimum and maximum values in all numeric fields ${latestSchemaInfo.path}`, () => {
+                            traverseSchema(latestSchemaInfo.schema, (obj) => {
+                                const fieldName = arguments[6]; // Little hack to avoid putting 5 unused args
+                                if (['number', 'integer'].includes(obj.type)) {
+                                    assert.ok(typeof obj.minimum === 'number', `field titled ${fieldName} doesn\'t have a minimum value`);
+                                    assert.ok(typeof obj.maximum === 'number', `field titled ${fieldName} doesn\'t have a maximum value`);
+                                }
+                            })
+                        });
+
                         it(`Should not have minimum or maximum values outside the bounds specified in options ${latestSchemaInfo.path}`, () => {
                             const enforcedMin = options.enforcedNumericBounds[0];
                             const enforcedMax = options.enforcedNumericBounds[1];

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "js-yaml": "^3.13.1",
     "json-schema-merge-allof": "^0.6.0",
     "json-schema-ref-parser": "^7.1.1",
+    "json-schema-traverse": "^0.4.1",
     "lodash": "^4.17.15",
     "pino": "^5.13.2",
     "pino-pretty": "^3.2.1",

--- a/scripts/jsonschema-tools.js
+++ b/scripts/jsonschema-tools.js
@@ -6,8 +6,8 @@ const path  = require('path');
 const yargs = require('yargs');
 
 const {
-    dereferenceSchema,
-    materializeSchemaVersion,
+    materializeSchema,
+    materializeSchemaToPath,
     materializeModifiedSchemas,
     materializeAllSchemas,
     readObject,
@@ -181,7 +181,7 @@ async function dereference(args) {
 
     const schemas = await Promise.all(schemaPaths.map(async (schemaPath) => {
         try {
-            return await dereferenceSchema(await readObject(schemaPath), options);
+            return await materializeSchema(await readObject(schemaPath), options);
         } catch (err) {
             options.log.fatal(err, `Failed dereferencing schema at ${schemaPath}`);
             process.exit(1);
@@ -221,7 +221,7 @@ async function materialize(args) {
         try {
             options.log.info(`Reading schema from ${schemaPath}`);
             let schema = await readObject(schemaPath);
-            await materializeSchemaVersion(schemaDirectory, schema, options);
+            await materializeSchemaToPath(schemaDirectory, schema, options);
         } catch (err) {
             options.log.fatal(err, `Failed materializing schema from ${schemaPath} into ${schemaDirectory}.`);
             process.exit(1);

--- a/test/test.js
+++ b/test/test.js
@@ -395,7 +395,7 @@ describe('getSchemaById', function() {
 });
 
 describe('Numeric bounds enforcement', function() {
-    it('should apply maxi and min by default if bounds aren\'t configured', async () => {
+    it('should apply max and min by default if bounds aren\'t configured', async () => {
         const customOptions = {};
         const options = readConfig(customOptions, true);
         const schema = expectedBasicDereferencedSchema;

--- a/test/test.js
+++ b/test/test.js
@@ -91,26 +91,6 @@ const expectedBasicDereferencedSchema = {
     required: ['$schema', 'test'],
 };
 
-const expectedBasicDereferencedSchemaBounded = {
-    title: 'basic',
-    description: 'Schema used for simple tests',
-    $id: '/basic/1.2.0',
-    $schema: 'https://json-schema.org/draft-07/schema#',
-    type: 'object',
-    additionalProperties: false,
-    properties: {
-        $schema: {
-            type: 'string',
-            description: 'The URI identifying the jsonschema for this event. This may be just a short uri containing only the name and revision at the end of the URI path.  e.g. /schema_name/12345 is acceptable. This often will (and should) match the schema\'s $id field.\n',
-        },
-        test_number: {
-            type: 'number',
-            minimum: -400,
-            maximum: 1200
-        }
-    },
-    required: ['$schema', 'test'],
-};
 /* eslint camelcase: 0 */
 
 describe('materializeSchemaToPath', function() {
@@ -415,22 +395,19 @@ describe('getSchemaById', function() {
 });
 
 describe('Numeric bounds enforcement', function() {
-    it('should apply maximum and minimum by default if bounds aren\'t configured', async () => {
+    it('should apply maxi and min by default if bounds aren\'t configured', async () => {
         const customOptions = {};
         const options = readConfig(customOptions, true);
-        const materializedSchema = await materializeSchema(expectedBasicDereferencedSchema, options);
-        assert(materializedSchema.properties.test_integer.minimum === Number.MIN_SAFE_INTEGER);
-        assert(materializedSchema.properties.test_integer.maximum === Number.MAX_SAFE_INTEGER);
-    });
-
-    it('should overwrite maximum and minimum if configured are out of bounds', async () => {
-        const customOptions = {
-            enforcedNumericBounds: [1,2]
-        };
-        const options = readConfig(customOptions, true);
-        const materializedSchema = await materializeSchema(expectedBasicDereferencedSchemaBounded, options);
-        assert(materializedSchema.properties.test_number.minimum === 1);
-        assert(materializedSchema.properties.test_number.maximum === 2);
+        const schema = expectedBasicDereferencedSchema;
+        const materializedSchema = await materializeSchema(schema, options);
+        assert(
+            materializedSchema.properties.test_integer.minimum ===
+            Number.MIN_SAFE_INTEGER
+        );
+        assert(
+            materializedSchema.properties.test_integer.maximum ===
+            Number.MAX_SAFE_INTEGER
+        );
     });
 
     it('should not apply bounds if option is null', async () => {
@@ -438,11 +415,12 @@ describe('Numeric bounds enforcement', function() {
             enforcedNumericBounds: null
         };
         const options = readConfig(customOptions, true);
-        const materializedSchema = await materializeSchema(expectedBasicDereferencedSchema, options);
+        const schema = expectedBasicDereferencedSchema;
+        const materializedSchema = await materializeSchema(schema, options);
         assert(!materializedSchema.properties.test_integer.minimum);
         assert(!materializedSchema.properties.test_integer.maximum);
-    })
-})
+    });
+});
 
 describe('Test Schema Repository Tests', function() {
     let fixture;

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,8 @@ const yaml = require('js-yaml');
 const assert = require('assert');
 
 const {
-    materializeSchemaVersion,
+    materializeSchemaToPath,
+    materializeSchema,
     findSchemasByTitleAndMajor,
     readConfig,
     getSchemaById,
@@ -89,9 +90,30 @@ const expectedBasicDereferencedSchema = {
     },
     required: ['$schema', 'test'],
 };
+
+const expectedBasicDereferencedSchemaBounded = {
+    title: 'basic',
+    description: 'Schema used for simple tests',
+    $id: '/basic/1.2.0',
+    $schema: 'https://json-schema.org/draft-07/schema#',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        $schema: {
+            type: 'string',
+            description: 'The URI identifying the jsonschema for this event. This may be just a short uri containing only the name and revision at the end of the URI path.  e.g. /schema_name/12345 is acceptable. This often will (and should) match the schema\'s $id field.\n',
+        },
+        test_number: {
+            type: 'number',
+            minimum: -400,
+            maximum: 1200
+        }
+    },
+    required: ['$schema', 'test'],
+};
 /* eslint camelcase: 0 */
 
-describe('materializeSchemaVersion', function() {
+describe('materializeSchemaToPath', function() {
     let tests = [
         {
             name: 'should materialize new yaml version from file with extensionless symlink',
@@ -248,7 +270,7 @@ describe('materializeSchemaVersion', function() {
             const schemaDirectory = path.dirname(schemaFile);
             const schema = yaml.safeLoad(await fse.readFile(schemaFile, 'utf-8'));
 
-            const materializedFiles = await materializeSchemaVersion(
+            const materializedFiles = await materializeSchemaToPath(
                 schemaDirectory, schema, test.options
             );
 
@@ -392,7 +414,35 @@ describe('getSchemaById', function() {
     });
 });
 
+describe('Numeric bounds enforcement', function() {
+    it('should apply maximum and minimum by default if bounds aren\'t configured', async () => {
+        const customOptions = {};
+        const options = readConfig(customOptions, true);
+        const materializedSchema = await materializeSchema(expectedBasicDereferencedSchema, options);
+        assert(materializedSchema.properties.test_integer.minimum === Number.MIN_SAFE_INTEGER);
+        assert(materializedSchema.properties.test_integer.maximum === Number.MAX_SAFE_INTEGER);
+    });
 
+    it('should overwrite maximum and minimum if configured are out of bounds', async () => {
+        const customOptions = {
+            enforcedNumericBounds: [1,2]
+        };
+        const options = readConfig(customOptions, true);
+        const materializedSchema = await materializeSchema(expectedBasicDereferencedSchemaBounded, options);
+        assert(materializedSchema.properties.test_number.minimum === 1);
+        assert(materializedSchema.properties.test_number.maximum === 2);
+    });
+
+    it('should not apply bounds if option is null', async () => {
+        const customOptions = {
+            enforcedNumericBounds: null
+        };
+        const options = readConfig(customOptions, true);
+        const materializedSchema = await materializeSchema(expectedBasicDereferencedSchema, options);
+        assert(!materializedSchema.properties.test_integer.minimum);
+        assert(!materializedSchema.properties.test_integer.maximum);
+    })
+})
 
 describe('Test Schema Repository Tests', function() {
     let fixture;


### PR DESCRIPTION
This option configures a pair of numeric bounds that, at the
schema materialization level, will apply those bounds to number
fields (float, integer or number) by traversing the schema.

The change includes a small refactor that separates the logic that
modifies the materialized schema from the main function that
outputs the materialized schema to a path.

Bug: T258659
https://phabricator.wikimedia.org/T258659