### PR TITLE
properly parse versions from $ids with numbers

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -387,9 +387,10 @@ async function getSchemaById(schemaId, options) {
 }
 
 /**
- * Returns a semantic version from a schema given a field
- * in that schema that contains the version.
+ * Returns a semantic version from a schema given a slash-delimited field
+ * in that schema whose final element contains the version number.
  * This uses semver.coerce to get the version.
+ * This is exported only for testing.
  * @param {Object} schema
  * @param {string} schemaVersionField
  *  field in schema that contains version,
@@ -397,7 +398,7 @@ async function getSchemaById(schemaId, options) {
  * @return {string} semantic version
  */
 function schemaVersion(schema, schemaVersionField) {
-    return semver.coerce(_.get(schema, schemaVersionField)).version;
+    return semver.coerce(_.get(schema, schemaVersionField).split('/').slice(-1)[0]).version;
 }
 
 /**
@@ -938,5 +939,6 @@ module.exports = {
     findSchemaPaths,
     findAllSchemasInfo,
     findSchemasByTitle,
-    findSchemasByTitleAndMajor
+    findSchemasByTitleAndMajor,
+    schemaVersion,
 };

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -41,6 +41,8 @@ const defaultOptions = {
     currentName: 'current.yaml',
     /**
      * Field in schema from which to extract the version using semver.coerce.
+     * If the value in this field looks like a URI path, only the final
+     * basename element of the path will be used to infer the schema version.
      */
     schemaVersionField: '$id',
     /**
@@ -387,9 +389,11 @@ async function getSchemaById(schemaId, options) {
 }
 
 /**
- * Returns a semantic version from a schema given a slash-delimited field
- * in that schema whose final element contains the version number.
+ * Returns a semantic version from a schema given a field
+ * in that schema that contains the version number.
  * This uses semver.coerce to get the version.
+ * If the schemaVersionField's value looks like a URI path,
+ * only the final basename element will be used to infer the schema.
  * This is exported only for testing.
  * @param {Object} schema
  * @param {string} schemaVersionField
@@ -398,7 +402,9 @@ async function getSchemaById(schemaId, options) {
  * @return {string} semantic version
  */
 function schemaVersion(schema, schemaVersionField) {
-    return semver.coerce(_.get(schema, schemaVersionField).split('/').slice(-1)[0]).version;
+    return semver.coerce(
+        path.basename(_.get(schema, schemaVersionField))
+    ).version;
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@ const {
     readConfig,
     getSchemaById,
     materializeAllSchemas,
+    schemaVersion,
     tests
 } = require('../index.js');
 
@@ -391,6 +392,19 @@ describe('getSchemaById', function() {
         assert.rejects(async () => {
             await getSchemaById('/nonexistent/1.0.0', options);
         });
+    });
+});
+
+describe('Reasonable schema version number parsing', function() {
+    it('should parse versions from $id strings', async () => {
+        assert(schemaVersion(expectedBasicSchema, '$id') === '1.2.0');
+    });
+
+    it('should parse $id strings with embedded numerals', async () => {
+        const barebonesSchema = {
+            $id: '/w3c/reportingapi/report/1.2.3',
+        };
+        assert(schemaVersion(barebonesSchema, '$id') === '1.2.3');
     });
 });
 


### PR DESCRIPTION
Previously, when $id strings were passed directly to semver.coerce(),
$ids like '/w3c/reportingapi/report/1.2.3' would have been parsed as
version number '3.0.0'.