### PR TITLE
Fix bug in enforced numeric bounds if max or min is 0

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -913,9 +913,10 @@ function enforceNumericBounds(schema, bounds) {
     const enforcedMax = bounds[1];
     traverseSchema(schemaCopy, (obj) => {
         if (['number', 'integer'].includes(obj.type)) {
-            obj.minimum = obj.minimum || enforcedMin;
-            obj.maximum = obj.maximum || enforcedMax;
+            obj.minimum = _.isUndefined(obj.minimum) ? enforcedMin : obj.minimum;
+            obj.maximum = _.isUndefined(obj.maximum) ? enforcedMax : obj.maximum;
         }
+
     })
     return schemaCopy;
 }

--- a/test/fixtures/schemas/basic/1.1.0.yaml
+++ b/test/fixtures/schemas/basic/1.1.0.yaml
@@ -16,6 +16,9 @@ properties:
     default: default test
   test_number:
     type: number
+    maximum: 9007199254740991
+    minimum: -9007199254740991
+
   test_map:
     description: >
       We want to support 'map' types using additionalProperties to specify the

--- a/test/fixtures/schemas/basic/current.yaml
+++ b/test/fixtures/schemas/basic/current.yaml
@@ -17,6 +17,7 @@ allOf:
 
       test_integer:
         type: integer
+        minimum: 0
 
       test_map:
         description: >


### PR DESCRIPTION
- Fix bug where a min or max of 0 was being interpreted as false and overwritten with bound
- Fix tests to handle this

Bug: T258659