### PR TITLE
Add option to generate schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,11 @@ configPaths: ['./.jsonschema-tools.yaml']
 # that they are at least within these bounds.
 enforcedNumericBounds: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
 
-# If true, repository tests for schemas will fail if the schema doesn't have
-# examples.  If it does have examples, they will be also tested for
-# validation against the schema.
-requireExamples: false
+# If true an example will be generated during schema materialization.
+# Examples already present in the schema will be preserved. E.g. If the
+# schema already has examples, and shouldGenerateExample is true,
+# no new example will be generated.
+shouldGenerateExample: false
 ```
 
 # Schema Repository Tests

--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -1,18 +1,19 @@
 'use strict';
 
-const _              = require('lodash');
-const yaml           = require('js-yaml');
-const path           = require('path');
-const semver         = require('semver');
-const readdirSync    = require('recursive-readdir-sync');
-const fse            = require('fs-extra');
-const pino           = require('pino');
-const util           = require('util');
-const exec           = util.promisify(require('child_process').exec);
-const RefParser      = require('json-schema-ref-parser');
-const mergeAllOf     = require('json-schema-merge-allof');
-const traverseSchema = require('json-schema-traverse');
-const Promise        = require('bluebird');
+const _               = require('lodash');
+const yaml            = require('js-yaml');
+const path            = require('path');
+const semver          = require('semver');
+const readdirSync     = require('recursive-readdir-sync');
+const fse             = require('fs-extra');
+const pino            = require('pino');
+const util            = require('util');
+const exec            = util.promisify(require('child_process').exec);
+const RefParser       = require('json-schema-ref-parser');
+const mergeAllOf      = require('json-schema-merge-allof');
+const jsonSchemaFaker = require('json-schema-faker');
+const traverseSchema  = require('json-schema-traverse');
+const Promise         = require('bluebird');
 
 /**
  * Default options for various functions in this library.
@@ -108,8 +109,39 @@ const defaultOptions = {
      * present, and will modify their value if they outside the configured bounds.
      */
     enforcedNumericBounds: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+
+    /**
+     * If true an example will be generated during schema materialization.
+     * Examples already present in the schema will be preserved. E.g. If the
+     * schema already has examples, and shouldGenerateExample is true,
+     * no new example will be generated.
+     */
+    shouldGenerateExample: false,
 };
 
+/**
+ * options for json-schema-faker when generating schema examples.
+ */
+const jsonSchemaFakerOptions = {
+    // If useExampleValue is true and an optional field is missing
+    // in an existent schema example,
+    // json-schema-faker will not set that field to a fake value,
+    // even if alwaysFakeOptionals is true.  The best thing to do is
+    // is to not useExamplesValue.
+    useExamplesValue: false,
+    useDefaultValue: true,
+    alwaysFakeOptionals: true,
+    // We want deterministicly generated examples.
+    // By setting this to a constant value, json-schema-faker
+    // will always return the same example value for the
+    // same type of field.
+    random: () => 0.15
+};
+
+// configure our jsonSchemaFaker to generate deterministic examples.
+jsonSchemaFaker.option(jsonSchemaFakerOptions);
+// Always generate a valid static example url for any field that uses uri-reference.
+jsonSchemaFaker.format('uri-reference', () => 'http://example.org');
 
 /**
  * When serializing YAML, schema keys will be sorted in this order.
@@ -604,6 +636,34 @@ async function dereferenceSchema(schema, options = {}) {
         });
 }
 
+
+/**
+ * If the schema doesn't already have an example,
+ * generate one and add it to the schema examples.
+ *
+ * @param {Object} schema
+ * @param {Object} options
+ * @param {string} options.schemaVersionField
+ *  If the schema has a $schema property, in the example it
+ *  will always be set to the schemaVersionField ($id)
+ *  of the schema.
+ * @return {Object}
+ */
+function generateSchemaExample(schema, options) {
+    options = readConfig(options);
+
+    // Only generate and the example if the schema doesn't already have an example.
+    if  (_.isEmpty(schema.examples)) {
+        const example = jsonSchemaFaker.generate(schema);
+        // make sure $schema is the same as $schema id.
+        if (_.has(example, '$schema')) {
+            example.$schema = _.get(schema, options.schemaVersionField);
+        }
+        schema.examples = [example];
+    }
+    return schema;
+}
+
 /**
  * Outputs a given schema with any modifications specified in the options,
  * including but not limited to dereferencing and enforcing numeric bounds.
@@ -618,6 +678,9 @@ async function materializeSchema (schema, options) {
     }
     if (options.enforcedNumericBounds) {
         schema = enforceNumericBounds(schema, options.enforcedNumericBounds);
+    }
+    if (options.shouldGenerateExample) {
+        schema = generateSchemaExample(schema, options);
     }
     return schema;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -822,6 +822,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1338,6 +1343,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format-util": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
     "formstream": {
       "version": "1.1.0",
@@ -2194,6 +2204,36 @@
         "lodash": "^4.17.4"
       }
     },
+    "json-schema-faker": {
+      "version": "0.5.0-rcv.32",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.32.tgz",
+      "integrity": "sha512-buGuuOhzxrf9FWGFybiGNiflGODIC5doU0r23+3MAOyjMR9/KsKolHANSbQnM4N+mmw/dbv9byT3oKZ1wp8v2A==",
+      "requires": {
+        "json-schema-ref-parser": "^6.1.0",
+        "jsonpath-plus": "^3.0.0",
+        "randexp": "^0.5.3"
+      },
+      "dependencies": {
+        "json-schema-ref-parser": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+          "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "js-yaml": "^3.12.1",
+            "ono": "^4.0.11"
+          }
+        },
+        "ono": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+          "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+          "requires": {
+            "format-util": "^1.0.3"
+          }
+        }
+      }
+    },
     "json-schema-merge-allof": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
@@ -2244,6 +2284,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonpath-plus": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-3.0.0.tgz",
+      "integrity": "sha512-WQwgWEBgn+SJU1tlDa/GiY5/ngRpa9yrSj8n4BYPHcwoxTDaMEaYCHMOn42hIHHDd3CrUoRr3+HpsK0hCKoxzA=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -3449,6 +3494,15 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
       "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA=="
     },
+    "randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "requires": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      }
+    },
     "raw-body": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
@@ -3602,6 +3656,11 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
     },
     "rimraf": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bluebird": "^3.5.5",
     "fs-extra": "^8.1.0",
     "js-yaml": "^3.13.1",
+    "json-schema-faker": "^0.5.0-rcv.32",
     "json-schema-merge-allof": "^0.6.0",
     "json-schema-ref-parser": "^7.1.1",
     "json-schema-traverse": "^0.4.1",

--- a/test/fixtures/schemas/basic/current.yaml
+++ b/test/fixtures/schemas/basic/current.yaml
@@ -25,6 +25,12 @@ allOf:
         type: object
         additionalProperties:
           type: string
+      
+      test_uri:
+        type: string
+        format: uri-reference
+        maxLength: 1024
+
     required:
       - test
     examples:


### PR DESCRIPTION
If shouldGenerateExample is true, an example will be generated during
schema materialization.

Examples already present in the schema will be preserved. E.g. If the
schema already has examples, and shouldGenerateExample is true,
no new example will be generated.

Bug: T270134