### PR TITLE
Return minor versions in order

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -989,12 +989,14 @@ function findSchemasByTitle(options = {}) {
 function groupSchemasByTitleAndMajor(schemaInfos) {
     const schemaInfosByTitle = groupSchemasByTitle(schemaInfos);
 
-    const schemaByTitleMajor = {};
-    _.keys(schemaInfosByTitle).forEach((title) => {
-        schemaByTitleMajor[title] = _.groupBy(
-            schemaInfosByTitle[title], info => semver.parse(info.version).major
-        );
-    });
+    const schemaByTitleMajor = _.chain(schemaInfosByTitle)
+        .mapValues(info =>
+            _.chain(info)
+            .groupBy(info => semver.parse(info.version).major)
+            .mapValues(minorSequence => minorSequence.sort(schemaInfoCompare))
+            .value()
+        )
+        .value();
     return schemaByTitleMajor;
 }
 


### PR DESCRIPTION
This keeps the members of each major version sequence in order, for
example ["1.0.0", "1.1.0", "1.2.0"].

Bug: T272861