### PR TITLE
Parentheses to ensure operator priority

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -925,14 +925,14 @@ function schemaInfoCompare(infoA, infoB) {
     // (If common is in the title, assume it is likely a dependency schema.)
     const infoACommon = infoA.title.includes('common');
     const infoBCommon = infoB.title.includes('common');
-    return infoACommon === infoBCommon ? 0 : (infoACommon ? -1 : 1) ||
+    return (infoACommon === infoBCommon ? 0 : (infoACommon ? -1 : 1)) ||
         // Then sort by path hierarchy depth.  Likely shorter hierarchy schemas
         // should be rendered before others.
         infoA.path.split('/').length - infoB.path.split('/').length ||
         // else if they are the same title, then sort by semver
         semver.compare(infoA.version, infoB.version) ||
         // if they are the same version, check current. Current should be later.
-        infoA.current === infoB.current ? 0 : (infoB.current ? -1 : 1);
+        (infoA.current === infoB.current ? 0 : (infoB.current ? -1 : 1));
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -407,7 +407,7 @@ describe('findSchemasByTitleAndMajor', function() {
         // Force re-reading of (default) config options.
         const options = readConfig({ schemaBasePath: fixture.resolve('schemas/') }, true);
         const schemasByTitleAndMajor = findSchemasByTitleAndMajor(options);
-        assert.deepStrictEqual(_.keys(schemasByTitleAndMajor), ['basic', 'common']);
+        assert.deepStrictEqual(_.keys(schemasByTitleAndMajor), ['common', 'basic']);
         assert.deepStrictEqual(_.keys(schemasByTitleAndMajor.basic), ['1']);
         assert.deepStrictEqual(_.keys(schemasByTitleAndMajor.common), ['1']);
 


### PR DESCRIPTION
Boolean operators bind with higher priority than the ternary
operator, so these must be protected with parentheses.

Some test results change because we were previously sorting in a
quirky, out-of-order way.