### PR TITLE
Deterministic YAML key ordering

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -145,9 +145,10 @@ jsonSchemaFaker.format('uri-reference', () => 'http://example.org');
 
 /**
  * When serializing YAML, schema keys will be sorted in this order.
- * If a schema key is not specified here, its sort order is undefined.
+ * Keys with a fixed sort order will appear first, remaining keys will be
+ * sorted alphabetically.
  */
-const schemaKeySortOrder = [
+const schemaKeySortOrder = _.invert([
     'title',
     'description',
     '$id',
@@ -158,7 +159,7 @@ const schemaKeySortOrder = [
     'properties',
     'allOf',
     'examples',
-];
+]);
 
 /**
  * Comparison function for schema keys.
@@ -166,11 +167,14 @@ const schemaKeySortOrder = [
  * @param {string} k2
  */
 function schemaKeyCompare(k1, k2) {
-    const sortOrder = _.invert(schemaKeySortOrder);
-    if (!(k1 in sortOrder) || !(k2 in sortOrder)) {
-        return 0;
+    if (k1 in schemaKeySortOrder && k2 in schemaKeySortOrder) {
+        return schemaKeySortOrder[k1] - schemaKeySortOrder[k2];
+    } else if (k1 in schemaKeySortOrder) {
+        return -1;
+    } else if (k2 in schemaKeySortOrder) {
+        return 1;
     }
-    return sortOrder[k1] - sortOrder[k2];
+    return k1.localeCompare(k2);
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,7 @@ const {
     getSchemaById,
     materializeAllSchemas,
     schemaVersion,
+    serialize,
     tests
 } = require('../index.js');
 
@@ -505,6 +506,42 @@ describe('Reasonable schema version number parsing', function() {
             $id: '/w3c/reportingapi/report/1.2.3',
         };
         assert(schemaVersion(barebonesSchema, '$id') === '1.2.3');
+    });
+});
+
+describe('YAML serialization key order', function() {
+    it('is deterministic', async () => {
+        let tests = [
+            {
+                keys: [ 'allOf', 'properties' ],
+                expected: [ 'properties', 'allOf' ],
+            },
+            {
+                keys: [ 'foo', 'properties' ],
+                expected: [ 'properties', 'foo' ],
+            },
+            {
+                keys: [ 'properties', 'foo' ],
+                expected: [ 'properties', 'foo' ],
+            },
+            {
+                keys: [ 'zebra', 'ant' ],
+                expected: [ 'ant', 'zebra' ],
+            },
+        ];
+
+        await Promise.all(tests.map(async (test) => {
+            assert.deepStrictEqual(
+                _.flow(
+                    () => test.keys,
+                    _.invert,
+                    serialize,
+                    yaml.load,
+                    Object.keys
+                )(),
+                test.expected
+            );
+        }));
     });
 });
 


### PR DESCRIPTION
Keys should have a deterministic order so that rematerializing gives
the same results each time.  This patch alphabetizes keys, and puts
the fixed set of keys ahead of all others.

Note that the key sorting affects every level of the output structure.