### PR TITLE
When resolving allOf examples, only keep one examples list

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -126,7 +126,7 @@ const defaultOptions = {
 
     /**
      * If true an example will be generated during schema materialization.
-     * Examples already present in the schema will be preserved. E.g. if the
+     * Examples already present in the schema will be preserved. E.g. If the
      * schema already has examples, and shouldGenerateExample is true,
      * no new example will be generated.
      */
@@ -579,19 +579,6 @@ function schemaPathToInfo(schemaPath, options = {}) {
 }
 
 /**
- * Cartesian product of arrays.
- * Taken from https://stackoverflow.com/a/43053803/555565
- * Example:
- *  cartesianProduct(['a','b'], ['c']) => [ [ 'a', 'c' ], [ 'b', 'c' ] ]
- *
- * @param  {...Array} arrays
- * @return {Array}
- */
-function cartesianProduct(...arrays) {
-    return arrays.reduce((a, b) => _.flatMap(a, d => b.map(e => _.flatten([d, e]))));
-}
-
-/**
  * Uses the options.schemaBaseUris to create http and file schema resolvers
  * that prefix schema URIs in $refs with with the base URIs.  These
  * resolved URLs are then dereferenced in place.
@@ -621,30 +608,12 @@ async function dereferenceSchema(schema, options = {}) {
             return mergeAllOf(dereferencedSchema, {
                 ignoreAdditionalProperties: true,
                 resolvers: {
-                    // Custom json-schema-merge-allof resolver for JSONSchema examples.
-                    // When merging schemas, we can assume that
-                    // the example values in each schema
-                    // can each be merged together, so that the
-                    // the merged example entries will validate
-                    // against the final merged schema.
-                    // By default, mergeAllOf concats arrays
-                    // to merge them, and JSONSchema examples is an array.
-                    // We want each element in each to-be-merged examples
-                    // to be merged together
-                    // I.e. we want merge(schemaA.examples[0], schemaB.examples[0]),
-                    // NOT schemaA.examples.concat(schemaB.examples) (the default).
-                    // To handle the case where the number of examples in the schemas
-                    // to merge differ, we take the cartesian produce of all examples
-                    // to merge.  This may inflate the number of examples after the merge
-                    // by quite a lot, but it seems like the only right thing to do.
-                    // Note that we reverse the candidate examples before we merge them.
-                    // We assume that schemas later in the allOf list to merge
-                    // have more complete and specific examples and want any
-                    // the final conflicting example values to take precedence.
-                    examples: (exampleListsToMerge, path, mergeSchemas) => {
-                        return cartesianProduct(...exampleListsToMerge)
-                            .map(examples => mergeSchemas(examples.reverse()));
-                    }
+                    // Use json-schema-merge-allof meta keyword (e.g. title)
+                    // resolver for JSONSchema examples.
+                    // This ends up just keeping the first examples value,
+                    // prioritizing the root schema.
+                    // See: https://github.com/mokkabonna/json-schema-merge-allof#lossy-vs-lossless
+                    examples: mergeAllOf.options.resolvers.title
                 }
             });
         })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "repository": {

--- a/test/fixtures/schemas/basic/current.yaml
+++ b/test/fixtures/schemas/basic/current.yaml
@@ -6,47 +6,49 @@ type: object
 additionalProperties: false
 allOf:
   - $ref: /common/1.0.0
-  - properties:
-      test:
-        type: string
-        default: default test
+properties:
+  test:
+    type: string
+    default: default test
 
-      test_number:
-        type: number
+  test_number:
+    type: number
 
-      test_integer:
-        type: integer
-        minimum: 0
+  test_integer:
+    type: integer
+    minimum: 0
 
-      test_map:
-        description: >
-          We want to support 'map' types using additionalProperties to specify
-          the value types.  (Keys are always strings.)
-        type: object
-        additionalProperties:
-          type: string
+  test_map:
+    description: >
+      We want to support 'map' types using additionalProperties to specify
+      the value types.  (Keys are always strings.)
+    type: object
+    additionalProperties:
+      type: string
 
-      test_enum:
-        description:
-          Only new entries to an enum should be allowed, and they can be provided in any order.
-        type: string
-        enum:
-          - val3
-          - val1
-          - val2
+  test_enum:
+    description:
+      Only new entries to an enum should be allowed, and they can be provided in any order.
+    type: string
+    enum:
+      - val3
+      - val1
+      - val2
 
-      test_uri:
-        type: string
-        format: uri-reference
-        maxLength: 1024
+  test_uri:
+    type: string
+    format: uri-reference
+    maxLength: 1024
 
-    required:
-      - test
-    examples:
-      - $schema: { $ref: '#/$id' }
-        test: test_string_value
-        test_number: 1.0
-        test_map:
-          keyA: valueA
-      - $schema: { $ref: '#/$id' }
-        test: test_string_value_2
+required:
+  - test
+examples:
+  - $schema: { $ref: '#/$id' }
+    dt: '2020-06-25T00:00:00Z'
+    test: test_string_value
+    test_number: 1.0
+    test_map:
+      keyA: valueA
+  - $schema: { $ref: '#/$id' }
+    dt: '2020-06-25T00:00:00Z'
+    test: test_string_value_2

--- a/test/test.js
+++ b/test/test.js
@@ -31,55 +31,55 @@ const expectedBasicSchema = {
     additionalProperties: false,
     allOf: [
         { $ref: '/common/1.0.0' },
+    ],
+    properties: {
+        test: {
+            type: 'string',
+            default: 'default test'
+        },
+        test_number: {
+            type: 'number',
+            maximum: 9007199254740991,
+            minimum: -9007199254740991
+        },
+        test_integer: {
+            type: 'integer',
+            maximum: 9007199254740991,
+            minimum: 0
+        },
+        test_map: {
+            description: 'We want to support \'map\' types using additionalProperties to specify the value types.  (Keys are always strings.)\n',
+            type: 'object',
+            additionalProperties: {
+                type: 'string'
+            }
+        },
+        test_enum: {
+            description: 'Only new entries to an enum should be allowed, and they can be provided in any order.',
+            type: 'string',
+            enum: ['val3', 'val1', 'val2'],
+        },
+        test_uri: {
+            type: 'string',
+            format: 'uri-reference',
+            maxLength: 1024
+        },
+    },
+    required: ['test'],
+    examples: [
         {
-            properties: {
-                test: {
-                    type: 'string',
-                    default: 'default test'
-                },
-                test_number: {
-                    type: 'number',
-                    maximum: 9007199254740991,
-                    minimum: -9007199254740991
-                },
-                test_integer: {
-                    type: 'integer',
-                    maximum: 9007199254740991,
-                    minimum: 0
-                },
-                test_map: {
-                    description: 'We want to support \'map\' types using additionalProperties to specify the value types.  (Keys are always strings.)\n',
-                    type: 'object',
-                    additionalProperties: {
-                        type: 'string'
-                    }
-                },
-                test_enum: {
-                    description: 'Only new entries to an enum should be allowed, and they can be provided in any order.',
-                    type: 'string',
-                    enum: ['val3', 'val1', 'val2'],
-                },
-                test_uri: {
-                    type: 'string',
-                    format: 'uri-reference',
-                    maxLength: 1024
-                },
-            },
-            required: ['test'],
-            examples: [
-                {
-                    $schema: { $ref: '#/$id' },
-                    test: 'test_string_value',
-                    test_number: 1.0,
-                    test_map: { keyA: 'valueA' },
-                },
-                {
-                    $schema: { $ref: '#/$id' },
-                    test: 'test_string_value_2',
-                },
-            ]
-        }
-    ]
+            $schema: { $ref: '#/$id' },
+            dt: '2020-06-25T00:00:00Z',
+            test: 'test_string_value',
+            test_number: 1.0,
+            test_map: { keyA: 'valueA' },
+        },
+        {
+            $schema: { $ref: '#/$id' },
+            dt: '2020-06-25T00:00:00Z',
+            test: 'test_string_value_2',
+        },
+    ],
 };
 
 const expectedBasicDereferencedSchema = {
@@ -135,27 +135,19 @@ const expectedBasicDereferencedSchema = {
     examples: [
         {
             // Even though both common and basic define $schema in their first example,
-            // Since the basic schema comes last in the list of allOf to merge,
-            // it's $schema value should take precedence when using jsonschema-tools'
-            // custom examples merge.
+            // The root (basic) schemas examples should take precedence when using
+            // jsonschema-tools custom examples merge.
             $schema: '/basic/1.2.0',
             dt: '2020-06-25T00:00:00Z',
             test: 'test_string_value',
             test_number: 1.0,
             test_map: { keyA: 'valueA' },
         },
-        // Examples are merged using a cartesian product of all refed examples too!
-        // /common/1.0.0 has one example and /basic/current.yaml (at 1.2.0) has 2 examples, so
-        // /basic/1.2.0 should end up with 2 examples:
-        //  common.examples X basic.examples => [
-        //      common.example[0] + basic.example[0],
-        //      common.example[0] + basic.example[1]
-        // ]
         {
             $schema: '/basic/1.2.0',
             dt: '2020-06-25T00:00:00Z',
             test: 'test_string_value_2',
-        }
+        },
     ]
 };
 
@@ -446,7 +438,6 @@ describe('findSchemasByTitleAndMajor', function() {
     });
 });
 
-
 describe('readConfig', function() {
     let fixture;
 
@@ -474,7 +465,6 @@ describe('readConfig', function() {
         assert.strictEqual(options.schemaTitleField, 'title'); // defaultOptions
     });
 });
-
 
 describe('getSchemaById', function() {
     let fixture;


### PR DESCRIPTION
#14 added fancy code to create a cartesian product of all possible list of examples and merge those.

This is cool, but I had some errors when actually merging examples like
this in real schema repos.  Perhaps something changed in
json-schema-merge-allof, but it now required me to add a defaultResolver
for non JSONSchema keywords that end up being passed to its mergeSchemas
function.  This could work, but I think the right thing to do is just
to keep the root schemas examples above all else.  This avoids
having to recurse into the examples objects themselves and merge them.

This means that examples in $ref-ed fragment schemas will
not be used, which I think is a more sensible behavior.

This undoes the examples merging added in #14 

Bug: T270134