### PR TITLE
Avoid running some robustness tests on current schema files

### DIFF
--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -141,6 +141,12 @@ const testCases = [
         name: 'schema-is-valid',
         description: 'must be a valid JSONSchema',
         assertFn: assertSchemaIsValid,
+        // current schema doesn't have to be valid as it
+        // can have unresolved $refs in it, and we don't
+        // dereference them for this test.
+        condition: (schemaInfo) => {
+            return !schemaInfo.current;
+        },
     },
     {
         name: 'schema-is-secure',
@@ -156,11 +162,18 @@ const testCases = [
         name: 'schema-monomorphic-types',
         description: 'has no union types',
         assertFn: assertMonomorphTypes,
+        // Types of propeties may be pulled in by $ref, so don't
+        // run this test on non-dereferenced current schemas.
+        condition: (schemaInfo) => {
+            return !schemaInfo.current;
+        },
     },
     {
         name: 'schema-required-properties-exist',
         description: 'all required properties must exist',
         assertFn: assertRequired,
+        // current schemas might have required properties
+        // declared via $ref, so don't run this test for current.
         condition: (schemaInfo) => {
             return !schemaInfo.current;
         },
@@ -169,8 +182,12 @@ const testCases = [
         name: 'schema-examples-$schema-matches-schema-$id',
         description: 'examples must have $schema == schema\'s $id',
         assertFn: assertExamplesId,
+        // current schema's examples should use $ref for example $schema,
+        // don't run on non derefernced current schema.
         condition: (schemaInfo) => {
-            return !schemaInfo.current && _.has(schemaInfo.schema, 'examples');
+            return !schemaInfo.current &&
+                _.has(schemaInfo.schema, 'examples') &&
+                _.has(schemaInfo.schema.properties, '$schema');
         },
     },
     {
@@ -190,8 +207,6 @@ const testCases = [
         },
     }
 ];
-
-
 
 
 function declareTests(options = {}) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "repository": {
@@ -35,7 +35,7 @@
     "fs-extra": "^8.1.0",
     "hosted-git-info": "^4.0.2",
     "js-yaml": "^3.13.1",
-    "json-schema-faker": "^0.5.0-rcv.32",
+    "json-schema-faker": "^0.5.0-rcv.34",
     "json-schema-merge-allof": "^0.6.0",
     "json-schema-ref-parser": "^7.1.1",
     "json-schema-traverse": "^0.4.1",


### PR DESCRIPTION
These tests might fail for a non-dereferenced current schema file.
E.g. A current schema file with a $ref might not be a valid JSONSchema
until derefernced.