### PR TITLE
Use fresh Ajv instance for schema validation tests

### DIFF
--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -9,23 +9,36 @@ const {
 const assert = require('assert').strict;
 const traverseSchema = require('json-schema-traverse');
 const _ = require('lodash');
-
 const Ajv = require('ajv');
-const ajv = new Ajv({
-    schemaId: '$id'
-});
-const isSchemaValid = ajv.compile(require('ajv/lib/refs/json-schema-draft-07.json'));
-const isSchemaSecure = ajv.compile(require('ajv/lib/refs/json-schema-secure.json'));
-// Both http and https can be used as the draft-07 $schema URL.
-// However, the draft-07 metaschema uses an http URL as its
-// $id field.  AJV caches schemas by their $id.  In order
-// to avoid a remote lookup of this metaschema if a
-// schema sets $schema to https, we manually cache the
-// local copy of draft-07 metaschema with the https URL.
-ajv.addSchema(
-    require('ajv/lib/refs/json-schema-draft-07.json'),
-    'https://json-schema.org/draft-07/schema'
-);
+
+
+/**
+ * Retuns a new Ajv instance. We need multiple ajv insttances
+ * for tests here because we may be adding the same schema
+ * from multiple files (.yaml, json, etc.) which will have the same
+ * $id. AJV will fail if the a schema with the same $id is added multiple times.
+ */
+function ajv() {
+    const ajv = new Ajv({
+        schemaId: '$id'
+    });
+    // Both http and https can be used as the draft-07 $schema URL.
+    // However, the draft-07 metaschema uses an http URL as its
+    // $id field.  AJV caches schemas by their $id.  In order
+    // to avoid a remote lookup of this metaschema if a
+    // schema sets $schema to https, we manually cache the
+    // local copy of draft-07 metaschema with the https URL.
+    ajv.addSchema(
+        require('ajv/lib/refs/json-schema-draft-07.json'),
+        'https://json-schema.org/draft-07/schema'
+    );
+
+    return ajv;
+}
+
+const isSchemaValid = ajv().compile(require('ajv/lib/refs/json-schema-draft-07.json'));
+const isSchemaSecure = ajv().compile(require('ajv/lib/refs/json-schema-secure.json'));
+
 
 function assertMonomorphTypes(node, path = '') {
     if (Array.isArray(node.type)) {
@@ -108,7 +121,7 @@ function assertExamplesId(schema) {
 
 function assertValidExamples(schema) {
     schema.examples.forEach((example, index) => {
-        if (!ajv.validate(schema, example)) {
+        if (!ajv().validate(schema, example)) {
             throw new assert.AssertionError({
                 message: `example ${index} did not validate against schema: ${ajv.errorsText()}`,
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "repository": {


### PR DESCRIPTION
Since we have multiple materalized files for the same schema version
(e.g. latest.yaml, 1.0.0.yaml, 1.0.0.json, etc.), we need to avoid
registering the same schema with the same Ajv instance when we run
tests on each of these schemas.