### PR TITLE
Never use $refed schema examples

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -602,12 +602,25 @@ async function dereferenceSchema(schema, options = {}) {
         }
     };
 
+    // Bug fix. We never want to use an $ref'd schema's examples field.
+    // However, if the $ref'd schema does have examples
+    // and the incoming schema doesn't, then by default the schemaResolver
+    // will pull in the $ref'ed schema's examples, there will be only one examples
+    // candidate, and mergeAllOf will end up just choosing
+    // the $ref'd schema's examples without any conflict to merge.
+    //
+    // To avoid this, check if the incoming schema examples field is defined.
+    // Since we ALWAYS and ONLY want to keep examples if they are from
+    // the incoming schema, use this do determine if we should
+    // delete the examples field from the schema after merging $refs.
+    const incomingSchemaHasExamples = !_.isUndefined(schema.examples);
+
     return RefParser.dereference(schema, refParserOptions)
         .then((dereferencedSchema) => {
             options.log.debug(
                 `Merging any allOf fields in schema with $id ${dereferencedSchema.$id}`
             );
-            return mergeAllOf(dereferencedSchema, {
+            const mergedSchema = mergeAllOf(dereferencedSchema, {
                 ignoreAdditionalProperties: true,
                 resolvers: {
                     // Use json-schema-merge-allof meta keyword (e.g. title)
@@ -618,6 +631,15 @@ async function dereferenceSchema(schema, options = {}) {
                     examples: mergeAllOf.options.resolvers.title
                 }
             });
+
+            // If the incoming schema didn't have examples,
+            // then delete examples that were added during
+            // dereferencing.
+            if (!incomingSchemaHasExamples) {
+                delete mergedSchema.examples;
+            }
+
+            return mergedSchema;
         })
         .catch((err) => {
             options.log.error(err, `Failed dereferencing schema with $id ${schema.$id}`, schema);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -392,6 +392,8 @@ describe('materializeSchemaToPath', function() {
             assert.ok(_.isInteger(materializedSchema.examples[0].test_integer));
             assert.ok(_.isNumber(materializedSchema.examples[0].test_number));
             assert.strictEqual(materializedSchema.examples[0].test_uri, 'http://example.org');
+            assert.strictEqual(materializedSchema.examples[0].$schema, '/basic/1.2.0');
+
         });
     });
 });


### PR DESCRIPTION
We never want to use an $ref'd schema's examples field.
However, if the $ref'd schema does have
examples the incoming schema doesn't, then by default the schemaResolver
will pull in the $ref'ed schema's examples, there will be only one examples
candidate, and mergeAllOf will end up just choosing
the $ref'd schema's examples without any conflict to merge.

To avoid this, check if the incoming schema examples field is defined.
Since we ALWAYS and ONLY want to keep examples if they are from
the incoming schema, use this do determine if we should
delete the examples field from the schema after merging $refs.

Bug: T270134