### PR TITLE
Fix assertValidExamples schema validation error

### DIFF
--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -121,9 +121,10 @@ function assertExamplesId(schema) {
 
 function assertValidExamples(schema) {
     schema.examples.forEach((example, index) => {
-        if (!ajv().validate(schema, example)) {
+        const validator = ajv();
+        if (!validator.validate(schema, example)) {
             throw new assert.AssertionError({
-                message: `example ${index} did not validate against schema: ${ajv.errorsText()}`,
+                message: `example ${index} did not validate against schema: ${validator.errorsText()}`,
             });
         }
     });


### PR DESCRIPTION
This was throwing `TypeError: ajv.errorsText is not a function`.