### PR TITLE
Add object type edge cases

### DIFF
--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -59,6 +59,29 @@ function assertDeterministicTypes(node, path = '') {
         assertDeterministicTypes(node.items, `${path}/items`);
     }
 
+    // if node type is object, assert it has a schema or is a map
+    if (node.type == 'object') {
+        const hasSchema = node.properties || node.oneOf || node.allOf;
+        if (!hasSchema && !node.additionalProperties) {
+            throw new assert.AssertionError({
+                message: `object type must specify schema or additionalProperties: #/${path}`
+            });
+        }
+
+        // Object types can't have additionalProperties
+        if (hasSchema && node.additionalProperties) {
+            throw new assert.AssertionError({
+                message: `object schema must be known ahead of time (no additionalProperties): #/${path}`
+            });
+        }
+
+        // map type
+        if (node.additionalProperties) {
+            // Assert additionalProperties type
+            assertDeterministicTypes(node.additionalProperties, `${path}/additionalProperties`);
+        }
+    }
+
     // if node has properties, assert their types.
     Object.keys(node.properties || {}).forEach((key) => {
         const keyPath = `${path}/properties/${key}`;
@@ -74,6 +97,36 @@ function assertDeterministicTypes(node, path = '') {
     (node.allOf || []).forEach((schema) => {
         assertDeterministicTypes(schema, path);
     });
+
+    // if node uses oneOf, assert that all types are the same and deterministic
+    if (node.oneOf && node.oneOf.length > 0) {
+        const {type} = node.oneOf[0];
+
+        // All types should be the same
+        const hasSameType = node.oneOf.every((schema) => schema.type === type);
+        if (!hasSameType) {
+            throw new assert.AssertionError({
+                message: `oneOf contains schemas with different types at #${path}`
+            });
+        }
+
+        // If object type, the required fields should be the same
+        if (type === 'object') {
+            const shape = node.oneOf[0].required || [];
+            node.oneOf.forEach(({required}) => {
+                const hasSameShape = shape.every(item => required.includes(item)) && required.every(item => shape.includes(item));
+                if (!hasSameShape) {
+                    throw new assert.AssertionError({
+                        message: `oneOf contains schemas with different types at #${path}`
+                    });
+                }
+            });
+        }
+
+        node.oneOf.forEach((schema) => {
+            assertDeterministicTypes(schema, path);
+        });
+    }
 }
 
 function assertSnakeCaseProperties(node, path = '') {

--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -235,6 +235,16 @@ const testCases = [
         assertFn: assertSnakeCaseProperties,
     },
     {
+        name: 'schema-monomorphic-types',
+        description: 'deprecated. Superseded by schema-deterministic-types',
+        assertFn: assertDeterministicTypes,
+        // Types of propeties may be pulled in by $ref, so don't
+        // run this test on non-dereferenced current schemas.
+        condition: (schemaInfo) => {
+            return !schemaInfo.current;
+        },
+    },
+    {
         name: 'schema-deterministic-types',
         description: 'has deterministic types (no unions, missing array value types, etc.)',
         assertFn: assertDeterministicTypes,

--- a/lib/tests/robustness.js
+++ b/lib/tests/robustness.js
@@ -64,14 +64,7 @@ function assertDeterministicTypes(node, path = '') {
         const hasSchema = node.properties || node.oneOf || node.allOf;
         if (!hasSchema && !node.additionalProperties) {
             throw new assert.AssertionError({
-                message: `object type must specify schema or additionalProperties: #/${path}`
-            });
-        }
-
-        // Object types can't have additionalProperties
-        if (hasSchema && node.additionalProperties) {
-            throw new assert.AssertionError({
-                message: `object schema must be known ahead of time (no additionalProperties): #/${path}`
+                message: `object type must specify properties or additionalProperties: #/${path}`
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/jsonschema-tools",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Utilties to help manage a repository of versioned JSONSchemas.",
   "homepage": "https://github.com/wikimedia/jsonschema-tools",
   "repository": {

--- a/test/fixtures/schemas/basic/1.1.0.yaml
+++ b/test/fixtures/schemas/basic/1.1.0.yaml
@@ -41,6 +41,24 @@ properties:
       - val1
       - val2
 
+  test_oneof:
+    type: object
+    oneOf:
+      - type: object
+        required:
+          - test
+        properties:
+          test:
+            type: string
+      - type: object
+        required:
+          - test
+        properties:
+          test:
+            type: string
+          test2:
+            type: string
+
 required:
   - $schema
   - test

--- a/test/fixtures/schemas/basic/current.yaml
+++ b/test/fixtures/schemas/basic/current.yaml
@@ -40,6 +40,24 @@ properties:
       - val1
       - val2
 
+  test_oneof:
+    type: object
+    oneOf:
+      - type: object
+        required:
+          - test
+        properties:
+          test:
+            type: string
+      - type: object
+        required:
+          - test
+        properties:
+          test:
+            type: string
+          test2:
+            type: string
+
   test_uri:
     type: string
     format: uri-reference

--- a/test/test.js
+++ b/test/test.js
@@ -797,16 +797,6 @@ describe('Test Schema Repository Tests', function() {
             );
         });
 
-        it('Should fail robustness test if an object field has properties and additionalProperties', async function() {
-            const schema = await getSchemaById('/basic/1.1.0', options);
-
-            schema.properties.test_map.properties = [{ test: { type: 'string' } }];
-            assert.throws(
-                () => assertDeterministicTypes(schema),
-                assert.AssertionError
-            );
-        });
-
         it('Should fail robustness test if additionalProperties type is a union', async function() {
             const schema = await getSchemaById('/basic/1.1.0', options);
 

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,32 @@ const expectedBasicSchema = {
             type: 'string',
             enum: ['val3', 'val1', 'val2'],
         },
+        test_oneof: {
+            type: 'object',
+            oneOf: [
+                {
+                    type: 'object',
+                    required: ['test'],
+                    properties: {
+                        test: {
+                            type: 'string'
+                        }
+                    }
+                },
+                {
+                    type: 'object',
+                    required: ['test'],
+                    properties: {
+                        test: {
+                            type: 'string'
+                        },
+                        test2: {
+                            type: 'string'
+                        }
+                    }
+                }
+            ]
+        },
         test_uri: {
             type: 'string',
             format: 'uri-reference',
@@ -136,6 +162,32 @@ const expectedBasicDereferencedSchema = {
             description: 'Only new entries to an enum should be allowed, and they can be provided in any order.',
             type: 'string',
             enum: ['val3', 'val1', 'val2'],
+        },
+        test_oneof: {
+            type: 'object',
+            oneOf: [
+                {
+                    type: 'object',
+                    required: ['test'],
+                    properties: {
+                        test: {
+                            type: 'string'
+                        }
+                    }
+                },
+                {
+                    type: 'object',
+                    required: ['test'],
+                    properties: {
+                        test: {
+                            type: 'string'
+                        },
+                        test2: {
+                            type: 'string'
+                        }
+                    }
+                }
+            ]
         },
         test_uri: {
             type: 'string',
@@ -720,4 +772,85 @@ describe('Test Schema Repository Tests', function() {
         );
     });
 
+    describe('object type robustness tests', function() {
+
+        let assertDeterministicTypes;
+        let options;
+
+        before('Setup schema', async function() {
+            const robustnessTests = rewire('../lib/tests/robustness');
+            assertDeterministicTypes = robustnessTests.__get__('assertDeterministicTypes');
+
+            options = readConfig({
+                schemaBasePath: fixture.resolve('schemas/'),
+                contentTypes: ['yaml'],
+            }, true);
+        });
+
+        it('Should fail robustness test if an object field does not have a schema', async function() {
+            const schema = await getSchemaById('/basic/1.1.0', options);
+
+            delete schema.properties.test_map.additionalProperties;
+            assert.throws(
+                () => assertDeterministicTypes(schema),
+                assert.AssertionError
+            );
+        });
+
+        it('Should fail robustness test if an object field has properties and additionalProperties', async function() {
+            const schema = await getSchemaById('/basic/1.1.0', options);
+
+            schema.properties.test_map.properties = [{ test: { type: 'string' } }];
+            assert.throws(
+                () => assertDeterministicTypes(schema),
+                assert.AssertionError
+            );
+        });
+
+        it('Should fail robustness test if additionalProperties type is a union', async function() {
+            const schema = await getSchemaById('/basic/1.1.0', options);
+
+            schema.properties.test_map.additionalProperties.type = ['string', 'number'];
+            assert.throws(
+                () => assertDeterministicTypes(schema),
+                assert.AssertionError
+            );
+        });
+    });
+
+    describe('oneOf robustness tests', function() {
+
+        let assertDeterministicTypes;
+        let options;
+
+        before('Setup schema', async function() {
+            const robustnessTests = rewire('../lib/tests/robustness');
+            assertDeterministicTypes = robustnessTests.__get__('assertDeterministicTypes');
+
+            options = readConfig({
+                schemaBasePath: fixture.resolve('schemas/'),
+                contentTypes: ['yaml'],
+            }, true);
+        });
+
+        it('Should fail robustness test if oneOf is of different types', async function() {
+            const schema = await getSchemaById('/basic/1.1.0', options);
+
+            schema.properties.test_oneof.oneOf[0].type = 'string';
+            assert.throws(
+                () => assertDeterministicTypes(schema),
+                assert.AssertionError
+            );
+        });
+
+        it('Should fail robustness test if oneOf objects have different required fields', async function() {
+            const schema = await getSchemaById('/basic/1.1.0', options);
+
+            schema.properties.test_oneof.oneOf[0].required = ['test2'];
+            assert.throws(
+                () => assertDeterministicTypes(schema),
+                assert.AssertionError
+            );
+        });
+    });
 });


### PR DESCRIPTION
- Fail if a schema uses oneOf with different types
- Fail if an object field does not have a schema

Bug: T337855
Bug: T338228