### PR TITLE
Add jsonschema-tools diff subcommand

### DIFF
--- a/lib/jsonschema-tools.js
+++ b/lib/jsonschema-tools.js
@@ -78,6 +78,11 @@ const defaultOptions = {
      */
     gitStaged: false,
     /**
+     * Commit to use with git diff commands.
+     * Used to finding modified schema files in a commit.
+     */
+    gitDiffCommit: 'HEAD',
+    /**
      * If true, materializeModified will `git add` any versioned schema files it materializes.
      */
     shouldGitAdd: true,
@@ -132,6 +137,11 @@ const defaultOptions = {
      * no new example will be generated.
      */
     shouldGenerateExample: false,
+
+    /**
+     * Command to use when running and printing a diff between schema versions.
+     */
+    diffCommand: 'diff --unified=0',
 };
 
 /**
@@ -343,6 +353,53 @@ function execCommand(command, execOptions, logger) {
     }
 }
 
+
+/**
+ * We want to especially avoid matching extensionless versioned file symlinks.
+ * 3.g. path/to/1.0.0 should not be retunred as path/to/1.0 after naively
+ * stripping the last '.0' as the 'file extension'.
+ * @constant
+ * @type {RegExp}
+ *
+ */
+const fileExtensionRegex = /^\.[a-zA-Z]\w*$/;
+
+/**
+ * Returns the file extension from filePath.
+ * path.extname works usually, but not for exensionless semver
+ * schema files, e.g. path.extname('path/to/1.0.0') woul return '.0';
+ * This ensures that the file extension matches fileExtensionRegex, or returns null.
+ *
+ * @param {string} filePath
+ * @return {string|null}
+ */
+function fileExtension(filePath) {
+    const parsedPath = path.parse(filePath);
+    // A file must have an extension that matches fileExtensionRegex
+    // for it to qualify as having an extension.
+    if (parsedPath.ext.match(fileExtensionRegex)) {
+        return parsedPath.ext;
+    } else {
+        return null;
+    }
+}
+
+/**
+ * Returns the filePath without a file extension.
+ * @param {string} filePath
+ * @return {string}
+ */
+function extensionlessPath(filePath) {
+    const parsedPath = path.parse(filePath);
+    // Avoid stripping a false 'extension' from a
+    // filePath without an extension.
+    if (parsedPath.ext.match(fileExtensionRegex)) {
+        return path.join(parsedPath.dir, parsedPath.name);
+    } else {
+        return filePath;
+    }
+}
+
 // https://tools.ietf.org/html/rfc3986#section-3.1
 const uriProtocolRegex = /^[a-zA-Z0-9+.-]+:\/\//;
 /**
@@ -486,13 +543,25 @@ function schemaVersion(schema, schemaVersionField) {
 }
 
 /**
- * Returns the filePath without a file extension.
- * @param {string} filePath
- * @return {string}
+ * Returns true of the file is a versioned schema file.
+ * This will be true if the extensionless basname of the file parses as a semver.
+ *
+ * @param {string} schemaFilePath
+ * @return {boolean}
  */
-function extensionlessPath(filePath) {
-    const parsedPath = path.parse(filePath);
-    return path.join(parsedPath.dir, parsedPath.name);
+function isVersionedSchemaFile(schemaFilePath) {
+    return !!semver.parse(extensionlessPath(path.basename(schemaFilePath)));
+}
+
+/**
+ * Returns true if schemaFilePath is a 'current' working schema file.
+ * @param {string} schemaFilePath
+ * @param {Object} options
+ * @return {boolean}
+ */
+function isCurrentSchemaFile(schemaFilePath, options = {}) {
+    options = readConfig(options);
+    return path.basename(schemaFilePath) === options.currentName;
 }
 
 /**
@@ -544,23 +613,61 @@ async function gitAdd(paths, options = {}) {
 }
 
 /**
- * Finds modified paths in options.schemaBasePath.  If options.gitStaged, this will look for
+ * Uses git to find all schema file paths that have been modified.
+ * If options.gitStaged, this will look for
  * modified staged files.  Else this will look for unstaged modified files.
  * File paths will be returned as absolute paths resolved relative to the
  * discovered git root of options.schemaBasePath.
+
  * @param {Object} options
+ * @param {boolean} options.gitStaged if true, the --cached flag will be passed to git diff.
+ * @param {string} options.gitDiffCommit commit to use when running git diff.
  * @return {Array<string>}
  */
 async function gitModifiedSchemaPaths(options = {}) {
     options = readConfig(options);
     const gitRoot = await findGitRoot(options);
+    // const execOptions = { cwd: gitRoot };
+
     const execOptions = { cwd: options.schemaBasePath };
-
-    const command = `git diff ${options.gitStaged ? '--cached' : ''} --name-only --diff-filter=ACM`;
-
-    const modifiedFiles = (await execCommand(command, execOptions, options.log)).stdout.trim().split('\n');
-    return _.filter(modifiedFiles, file => path.basename(file) === options.currentName)
+    const command = `git diff ${options.gitStaged ? '--cached' : ''} --name-only --diff-filter=ACM ${options.gitDiffCommit}`;
+    return (await execCommand(command, execOptions, options.log))
+        .stdout.trim().split('\n')
         .map(file => path.resolve(gitRoot, file));
+}
+
+/**
+ * Finds current working schema paths in options.schemaBasePath
+ * modified seince options.gitDiffCommit.
+ *
+ * See doc for gitModifiedSchemaPaths.
+ *
+ * @param {Object} options
+ * @param {boolean} options.gitStaged if true, the --cached flag will be passed to git diff.
+ * @param {string} options.gitDiffCommit commit to use when running git diff.
+ * @return {Array<string>}
+ */
+async function gitModifiedCurrentSchemaPaths(options = {}) {
+    options = readConfig(options);
+    const modifiedFiles = await gitModifiedSchemaPaths(options);
+    return modifiedFiles.filter(isCurrentSchemaFile);
+}
+
+/**
+ * Finds materialized versioned schema paths in options.schemaBasePath
+ * modified seince options.gitDiffCommit.
+ *
+ * See doc for gitModifiedSchemaPaths.
+ *
+ * @param {Object} options
+ * @param {boolean} options.gitStaged if true, the --cached flag will be passed to git diff.
+ * @param {string} options.gitDiffCommit commit to use when running git diff.
+ * @return {Array<string>}
+ */
+async function gitModifiedVersionedSchemaPaths(options = {}) {
+    options = readConfig(options);
+    const modifiedFiles = await gitModifiedSchemaPaths(options);
+    return modifiedFiles.filter(isVersionedSchemaFile);
 }
 
 /**
@@ -688,6 +795,29 @@ function generateSchemaExample(schema, options) {
     return schema;
 }
 
+
+/**
+ * Traverses through all the fields in the schema, including nested properties, and
+ * sets the numeric bounds specified in options when the object type is number.
+ * @param {Object} schema
+ * @param {Array} bounds as specified in options
+ * @return {Object} schema with bounded numeric fields
+ */
+function enforceNumericBounds(schema, bounds) {
+    const schemaCopy = _.cloneDeep(schema);
+    const enforcedMin = bounds[0];
+    const enforcedMax = bounds[1];
+    traverseSchema(schemaCopy, (obj) => {
+        if (['number', 'integer'].includes(obj.type)) {
+            obj.minimum = _.isUndefined(obj.minimum) ? enforcedMin : obj.minimum;
+            obj.maximum = _.isUndefined(obj.maximum) ? enforcedMax : obj.maximum;
+        }
+
+    });
+    return schemaCopy;
+}
+
+
 /**
  * Outputs a given schema with any modifications specified in the options,
  * including but not limited to dereferencing and enforcing numeric bounds.
@@ -730,7 +860,7 @@ async function materializeSchemaToPath(schemaDirectory, schema, options = {}) {
     return _.flatten(await Promise.all(options.contentTypes.map(async (contentType) => {
         let materializedFiles = [];
 
-        const materializedSchemaFileName = `${version}.${contentType}`
+        const materializedSchemaFileName = `${version}.${contentType}`;
         const materializedSchemaPath = path.join(schemaDirectory, materializedSchemaFileName);
 
         if (!options.dryRun) {
@@ -776,7 +906,6 @@ async function materializeSchemaToPath(schemaDirectory, schema, options = {}) {
                 (!fse.existsSync(latestSymlinkPath) ||
                 semver.compare(version, schemaPathToInfo(latestSymlinkPath, options).version) >= 0)
             ) {
-                const target = path.basename(materializedSchemaPath);
                 if (!options.dryRun) {
                     await createSymlink(materializedSchemaFileName, latestSymlinkPath);
                     log.info(
@@ -829,7 +958,7 @@ async function materializeSchemaToPath(schemaDirectory, schema, options = {}) {
  * @return {Promise<string>} path of newly materialized files
  */
 async function materializeSchemaVersion(schemaDirectory, schema, options = {}) {
-    return materializeSchemaToPath(schemaDirectory, schema, options)
+    return materializeSchemaToPath(schemaDirectory, schema, options);
 }
 
 /**
@@ -842,7 +971,7 @@ async function materializeModifiedSchemas(options = {}) {
     options = readConfig(options);
 
     options.log.info(`Looking for modified ${options.currentName} schema files in ${options.schemaBasePath}`);
-    const schemaPaths = await gitModifiedSchemaPaths(options);
+    const schemaPaths = await gitModifiedCurrentSchemaPaths(options);
 
     if (_.isEmpty(schemaPaths)) {
         options.log.info(`No modified ${options.currentName} schema files were found.`);
@@ -967,6 +1096,7 @@ function schemaInfoCompare(infoA, infoB) {
  * info and schema.
  * If any schema $id matches a regex in options.ignoreSchemas, it will
  * not be included in returned values.
+ *
  * @param {Object} options
  * @return {Object[]}
  */
@@ -997,7 +1127,6 @@ function groupSchemasByTitle(schemaInfos) {
 /**
  * Finds all schemas in options.schemaBasePath, converts them to schema info objects,
  * and groups them by schema title
- * @param {string} schemaBasePath
  * @param {Object} options
  * @return {Object}
  */
@@ -1042,8 +1171,7 @@ function findSchemasByTitleAndMajor(options = {}) {
  */
 async function materializeAllSchemas(options = {}) {
     options = readConfig(options);
-    const currentSchemasInfo = (await findAllSchemasInfo(options))
-    .filter(e => e.current);
+    const currentSchemasInfo = findAllSchemasInfo(options).filter(e => e.current);
 
     return _.flatten(await Promise.all(_.map(
         currentSchemasInfo,
@@ -1052,26 +1180,91 @@ async function materializeAllSchemas(options = {}) {
 }
 
 /**
- * Traverses through all the fields in the schema, including nested properties, and
- * sets the numeric bounds specified in options when the object type is number.
- * @param {Object} schema
- * @param {Array} bounds as specified in options
- * @return {Object} schema with bounded numeric fields
+ * Runs options.diffCommand between two files, and returns the output.
+ * @param {string} file1 path to first file
+ * @param {string} file2 path to second file
+ * @param {Object} options
+ * @return {string} diff output
  */
-function enforceNumericBounds(schema, bounds) {
-    const schemaCopy = _.cloneDeep(schema);
-    const enforcedMin = bounds[0];
-    const enforcedMax = bounds[1];
-    traverseSchema(schemaCopy, (obj) => {
-        if (['number', 'integer'].includes(obj.type)) {
-            obj.minimum = _.isUndefined(obj.minimum) ? enforcedMin : obj.minimum;
-            obj.maximum = _.isUndefined(obj.maximum) ? enforcedMax : obj.maximum;
-        }
+async function diff(file1, file2, options = {}) {
+    options = readConfig(options);
 
-    });
-    return schemaCopy;
+    try {
+        const result = await execCommand(
+            `${options.diffCommand} ${file1} ${file2}`,
+            null,
+            options.log
+        );
+        return result.stdout;
+    } catch (err) {
+        if (err.code === 1) {
+            // Regular diff will exit 1 if there are differences.
+            // This is not an error.
+            return err.stdout;
+        } else {
+            // Else just reraise the Error.
+            throw err;
+        }
+    }
 }
 
+/**
+ * Finds modified versioned schema files,
+ * diffs them against the previous version,
+ * and prints the output.
+ *
+ * @param {Object} options
+ */
+async function printDiffForGitModifiedVersionedSchemas(options = {}) {
+    options = readConfig(options);
+
+    const gitRoot = await findGitRoot(options);
+
+    // DRY function to return true if file is primary content type.
+    function isFilePrimaryContentType(filePath) {
+        return fileExtension(filePath) === '.' + options.contentTypes[0];
+    }
+
+    // All modified versioned paths in options.gitCommit that are of the 'primary' content type.
+    const modifiedVersionedSchemaPaths =
+        (await gitModifiedVersionedSchemaPaths(options))
+            .filter(isFilePrimaryContentType)
+            // Map back to relative paths since later we will be comparing
+            // to relative paths returned by findAllSchemasInfo.
+            .map(f => path.relative(gitRoot, f));
+
+
+    // Get all of the schemaInfos that are for versioned
+    // materialized files of only the 'primary' content type
+    // and group them by title.
+    // We only want to diff the versioned schemas once, so if
+    // there are multiple materialized content types (e.g. yaml and json),
+    // we only want to diff the first in the list of configured contentTypes.
+    const versionedSchemaInfosByTitle = groupSchemasByTitle(
+        findAllSchemasInfo(options).filter(
+            (schemaInfo) => {
+                return isVersionedSchemaFile(schemaInfo.path) &&
+                  isFilePrimaryContentType(schemaInfo.path);
+            }
+        )
+    );
+
+    // Loop through each versioned schemaInfos in pairs of previous and next version.
+    // If next version's file path is in our list of modified schema files, then diff it with its
+    // previous version and print the diff output.
+    for (const schemaTitle of Object.keys(versionedSchemaInfosByTitle)) {
+        const schemaInfos = versionedSchemaInfosByTitle[schemaTitle];
+        for (let i = 0; i < schemaInfos.length - 1; i++) {
+            const prevSchemaFile = schemaInfos[i].path;
+            const nextSchemaFile = schemaInfos[i + 1].path;
+
+            if (modifiedVersionedSchemaPaths.includes(nextSchemaFile)) {
+                const diffOutput = await diff(prevSchemaFile, nextSchemaFile, options);
+                process.stdout.write(diffOutput);
+            }
+        }
+    }
+}
 
 module.exports = {
     defaultOptions,
@@ -1088,10 +1281,13 @@ module.exports = {
     materializeSchemaVersion,
     materializeModifiedSchemas,
     materializeAllSchemas,
+    gitModifiedCurrentSchemaPaths,
     schemaPathToInfo,
     findSchemaPaths,
     findAllSchemasInfo,
     findSchemasByTitle,
     findSchemasByTitleAndMajor,
     schemaVersion,
+    diff,
+    printDiffForGitModifiedVersionedSchemas
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "nyc mocha && npm run lint",
+    "test": "nyc --reporter=lcov --reporter=text-summary --reporter=html mocha && npm run lint",
     "lint": "eslint --cache --max-warnings 0 index.js test/test.js"
   },
   "bin": {

--- a/test/test.js
+++ b/test/test.js
@@ -228,6 +228,80 @@ delete expectedBasicDereferencedSchemaWithoutNumericBounds.properties.test_integ
 
 /* eslint camelcase: 0 */
 
+
+
+describe('jsonschema-tools utility functions', function() {
+
+    const jsToolsRewired = rewire('../lib/jsonschema-tools.js');
+
+    it('fileExtension should return the file extension', function() {
+        const fileExtension = jsToolsRewired.__get__('fileExtension');
+        assert.strictEqual(fileExtension('a/b/c.yaml'), '.yaml');
+        assert.strictEqual(fileExtension('a/b/c.json'), '.json');
+        assert.strictEqual(fileExtension('a/b/1.0.0'), null)
+    });
+
+    it('extensionlessPath should remove extension from file path', function() {
+        const extensionlessPath = jsToolsRewired.__get__('extensionlessPath');
+        assert.strictEqual(extensionlessPath('/a/b/file.yaml'), '/a/b/file');
+        assert.strictEqual(extensionlessPath('a/b/file.yaml'), 'a/b/file');
+        assert.strictEqual(
+            extensionlessPath('a/b/file'),
+            'a/b/file',
+            'sholud not modify an extensionless path'
+        );
+        assert.strictEqual(
+            extensionlessPath('a/b/1.0.0'),
+            'a/b/1.0.0',
+            'should not modify extensionless versioned schema path'
+        );
+        assert.strictEqual(extensionlessPath('a/b/1.0.0.yaml'), 'a/b/1.0.0');
+    });
+
+    it('uriHasProtocol should determine if uri has protocol', function() {
+        const uriHasProtocol = jsToolsRewired.__get__('uriHasProtocol');
+        assert.strictEqual(uriHasProtocol('http://domain.example'), true);
+        assert.strictEqual(uriHasProtocol('file:///a/b'), true);
+        assert.strictEqual(uriHasProtocol('/a/b'), false);
+    });
+
+    it('resolveUri should resolve URIs with a base URI', function() {
+        const resolveUri = jsToolsRewired.__get__('resolveUri');
+        assert.strictEqual(
+            resolveUri('/a/b/c', 'http://domain.example/path/to/dir'),
+            'http://domain.example/path/to/dir/a/b/c'
+        );
+        assert.strictEqual(
+            resolveUri('/a/b/c', 'file:///path/to/dir'),
+            'file:///path/to/dir/a/b/c'
+        );
+        assert.strictEqual(
+            resolveUri('/a/b/c', '/path/to/dir'),
+            'file:///path/to/dir/a/b/c'
+        );
+    });
+
+    it('isVersionedSchemaFile should determine if a file path is a versioned schema file', function() {
+        const isVersionedSchemaFile = jsToolsRewired.__get__('isVersionedSchemaFile');
+        assert.strictEqual(isVersionedSchemaFile('/a/b/c/1.0.0'), true);
+        assert.strictEqual(isVersionedSchemaFile('/a/b/c/1.0.0.yaml'), true);
+        assert.strictEqual(isVersionedSchemaFile('a/b/c/1.0.0'), true);
+        assert.strictEqual(isVersionedSchemaFile('http://domain.example/a/b/c/1.0.0'), true);
+        assert.strictEqual(isVersionedSchemaFile('http://domain.example/a/b/c/current.yaml'), false);
+        assert.strictEqual(isVersionedSchemaFile('a/b/c/latest'), false);
+    });
+
+    it('isCurrentSchemaFile should determine if a file path is a current working schema file', function() {
+        const isCurrentSchemaFile = jsToolsRewired.__get__('isCurrentSchemaFile');
+        const options = { currentName: 'current' };
+        assert.strictEqual(isCurrentSchemaFile('/a/b/c/1.0.0', options), false);
+        assert.strictEqual(isCurrentSchemaFile('/a/b/c/1.0.0.yaml', options), false);
+        assert.strictEqual(isCurrentSchemaFile('/a/b/c/latest', options), false);
+        assert.strictEqual(isCurrentSchemaFile('/a/b/c/latest.yaml', options), false);
+        assert.strictEqual(isCurrentSchemaFile('/a/b/c/current.yaml', options), true);
+    });
+});
+
 describe('materializeSchemaToPath', function() {
     let tests = [
         {
@@ -462,7 +536,6 @@ describe('materializeSchemaToPath', function() {
         });
     });
 });
-
 
 describe('findSchemasByTitleAndMajor', function() {
     let fixture;

--- a/test/test.js
+++ b/test/test.js
@@ -238,7 +238,7 @@ describe('jsonschema-tools utility functions', function() {
         const fileExtension = jsToolsRewired.__get__('fileExtension');
         assert.strictEqual(fileExtension('a/b/c.yaml'), '.yaml');
         assert.strictEqual(fileExtension('a/b/c.json'), '.json');
-        assert.strictEqual(fileExtension('a/b/1.0.0'), null)
+        assert.strictEqual(fileExtension('a/b/1.0.0'), null);
     });
 
     it('extensionlessPath should remove extension from file path', function() {


### PR DESCRIPTION
This finds materialized schema versions that have been modified since the previous commit, and then prints a diff between them.

This will make reviewing schema changes easier.  We can schedule jsonschema-tools diff to be run as a CI job, and reviewers can look at the output to compare e.g. version 1.0.0 to version 1.1.0, and so on.

In WMF CI, we should use dyff as the --diff-command to show semantic yaml diffs, instead of textual diffs.

Bug: T321850